### PR TITLE
feat: add run command for testing agent skills

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-cli"
-version = "2.0.0a7"
+version = "2.0.0a8"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-cli"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/weni_cli/cli.py
+++ b/weni_cli/cli.py
@@ -25,6 +25,31 @@ def init():
     InitHandler().execute()
 
 
+# Run Command
+@cli.command("run")
+@click.argument("definition", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.argument("agent", required=True, type=str)
+@click.argument("skill", required=True, type=str)
+@click.option(
+    "--file", "-f", help="The path to the test definition file", type=click.Path(exists=True, dir_okay=False)
+)
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+def run_test(definition, agent, skill, file, verbose):
+    """Run tests for a specific agent skill
+
+    DEFINITION: The path to the YAML agent definition file
+    AGENT: The agent name to be tested
+    SKILL: The skill name to be tested
+    FILE: The path to the test definition file
+    """
+    from weni_cli.commands.run import RunHandler
+
+    try:
+        RunHandler().execute(definition=definition, agent=agent, skill=skill, test_definition=file, verbose=verbose)
+    except Exception as e:
+        click.echo(f"Error: {e}")
+
+
 # Nested CLI Project Group
 @cli.group()
 def project():

--- a/weni_cli/clients/cli_client.py
+++ b/weni_cli/clients/cli_client.py
@@ -126,8 +126,8 @@ class CLIClient:
         data["test_definition"] = json.dumps(test_definition)
         data["skill_name"] = skill_name
         data["agent_name"] = agent_name
-        data["credentials"] = credentials
-        data["globals"] = skill_globals
+        data["skill_credentials"] = json.dumps(credentials)
+        data["skill_globals"] = json.dumps(skill_globals)
 
         files = {"skill": skill_folder}
 

--- a/weni_cli/clients/cli_client.py
+++ b/weni_cli/clients/cli_client.py
@@ -77,3 +77,71 @@ class CLIClient:
                                 raise Exception(
                                     f"{resp.get('message')} - Data: {resp.get('data', None)} - Request ID: {resp.get('request_id')}"
                                 )
+
+    def run_test(
+        self,
+        project_uuid,
+        definition,
+        skill_folder,
+        skill_name,
+        agent_name,
+        test_definition,
+        credentials,
+        skill_globals,
+        verbose=False,
+    ):
+
+        def display_test_progress(resp, verbose):
+            if not resp:
+                return
+
+            if not resp.get("success") and not resp.get("message"):
+                click.echo("Unknown error while running test")
+                return
+
+            if not resp.get("success"):
+                click.echo(resp.get("message"))
+                return
+
+            if resp.get("code") == "TEST_CASE_RUNNING":
+                click.echo(f"{resp.get('message')}...", nl=False)
+                return
+
+            if resp.get("code") == "TEST_CASE_COMPLETED":
+                if resp.get("data", {}).get("test_status_code") == 200:
+                    click.echo(click.style("PASS", fg="green"))
+                else:
+                    click.echo(click.style("FAILED", fg="red"))
+
+                if verbose:
+                    click.echo(click.style(f"{resp.get('data', {}).get('test_case')} Logs:", fg="yellow"))
+                    click.echo(resp.get("data", {}).get("test_response", {}))
+                    click.echo("\n")
+
+                return
+
+        url = f"{self.base_url}/api/v1/runs"
+
+        data = create_default_payload(project_uuid, definition)
+        data["test_definition"] = json.dumps(test_definition)
+        data["skill_name"] = skill_name
+        data["agent_name"] = agent_name
+        data["credentials"] = credentials
+        data["globals"] = skill_globals
+
+        files = {"skill": skill_folder}
+
+        s = requests.Session()
+
+        with spinner() as spin:
+            with s.post(
+                url, headers=self.headers, data=data, files=files, timeout=(10, None), stream=True
+            ) as response:
+                if response.status_code != 200:
+                    raise Exception(f"Failed to run test: {response.text}")
+
+                for line in response.iter_lines():
+                    if line:
+                        spin.stop()
+                        display_test_progress(json.loads(line), verbose)
+                        spin.start()

--- a/weni_cli/commands/run.py
+++ b/weni_cli/commands/run.py
@@ -1,0 +1,192 @@
+import click
+
+from slugify import slugify
+
+from weni_cli.clients.cli_client import CLIClient
+from weni_cli.handler import Handler
+from weni_cli.packager.packager import create_skill_folder_zip
+from weni_cli.store import STORE_PROJECT_UUID_KEY, Store
+from weni_cli.validators.definition import format_definition, load_definition
+
+
+DEFAULT_TEST_DEFINITION_FILE = "test_definition.yaml"
+
+
+class RunHandler(Handler):
+    def execute(self, **kwargs):
+        definition_path = kwargs.get("definition")
+        agent_name = kwargs.get("agent")
+        skill_name = kwargs.get("skill")
+        test_definition_path = kwargs.get("test_definition")
+        verbose = kwargs.get("verbose", False)
+        store = Store()
+        project_uuid = store.get(STORE_PROJECT_UUID_KEY)
+
+        if not project_uuid:
+            click.echo("No project selected, please select a project first")
+            return
+
+        definition_data = load_definition(definition_path)
+
+        if not definition_data:
+            return
+
+        if not test_definition_path:
+            test_definition_path = self.load_default_test_definition(definition_data, agent_name, skill_name)
+
+            if not test_definition_path:
+                click.echo(
+                    f"Error: Failed to get default test definition file: {DEFAULT_TEST_DEFINITION_FILE} in skill folder."
+                )
+                click.echo("You can use the --file option to specify a different file.")
+                return
+
+        skill_folder = self.load_skill_folder(definition_data, agent_name, skill_name)
+
+        if not skill_folder:
+            click.echo("Error: Failed to load skill folder")
+            return
+
+        definition = format_definition(definition_data)
+
+        if not definition:
+            return
+
+        test_definition = load_definition(test_definition_path)
+
+        if not test_definition:
+            return
+
+        skill_source_path = self.get_skill_source_path(definition_data, agent_name, skill_name)
+
+        credentials = self.load_skill_credentials(skill_source_path)
+
+        skill_globals = self.load_skill_globals(skill_source_path)
+
+        self.run_test(
+            project_uuid,
+            definition,
+            skill_folder,
+            skill_name,
+            agent_name,
+            test_definition,
+            credentials,
+            skill_globals,
+            verbose,
+        )
+
+    def parse_agent_skill(self, agent_skill) -> tuple[str, str]:
+        try:
+            return agent_skill.split(".")[0], agent_skill.split(".")[1]
+        except Exception:
+            return None, None
+
+    def get_skill_source_path(self, definition, agent_name, skill_name) -> str | None:
+        for _, data in definition.get("agents", {}).items():
+            if data.get("name") == agent_name:
+                for skill in data.get("skills", []):
+                    for _, skill_data in skill.items():
+                        if skill_data.get("name") == skill_name:
+                            return skill_data.get("source", {}).get("path")
+        return None
+
+    def load_skill_credentials(self, skill_source_path: str) -> dict | None:
+        credentials = {}
+        with open(f"{skill_source_path}/.env", "r") as file:
+            for line in file:
+                key, value = line.strip().split("=")
+                credentials[key] = value
+        return credentials
+
+    def load_skill_globals(self, skill_source_path: str) -> dict | None:
+        globals = {}
+        with open(f"{skill_source_path}/.globals", "r") as file:
+            for line in file:
+                key, value = line.strip().split("=")
+                globals[key] = value
+        return globals
+
+    def load_default_test_definition(self, definition, agent_name, skill_name) -> str | None:
+        try:
+            definition_path = None
+
+            for _, data in definition.get("agents", {}).items():
+                if data.get("name") == agent_name:
+                    for skill in data.get("skills", []):
+                        for _, skill_data in skill.items():
+                            if skill_data.get("name") == skill_name:
+                                path_test = skill_data.get("source", {}).get("path_test")
+                                skill_path = skill_data.get("source", {}).get("path")
+                                if skill_data.get("source", {}).get("path_test"):
+                                    definition_path = f"{skill_path}/{path_test}"
+                                else:
+                                    definition_path = f"{skill_path}/{DEFAULT_TEST_DEFINITION_FILE}"
+
+            if not definition_path:
+                return None
+
+            return definition_path
+        except Exception as e:
+            click.echo(f"Error: Failed to load default test definition file: {e}")
+            return None
+
+    def load_skill_folder(self, definition, agent_name, skill_name) -> bytes:
+        agent_data = None
+        for _, data in definition.get("agents", {}).items():
+            if data.get("name") == agent_name:
+                agent_data = data
+                break
+
+        if not agent_data:
+            click.echo(f"Error: Agent {agent_name} not found in definition")
+            return None
+
+        skills = agent_data.get("skills", [])
+
+        skill_data = None
+        for skill in skills:
+            for _, data in skill.items():
+                if data.get("name") == skill_name:
+                    skill_data = data
+                    break
+
+        if not skill_data:
+            click.echo(f"Error: Skill {skill_name} not found in agent {agent_name}")
+            return None
+
+        skill_slug = slugify(skill_data.get("name"))
+        skill_folder = create_skill_folder_zip(skill_slug, skill_data.get("source").get("path"))
+
+        if not skill_folder:
+            click.echo(f"Error: Failed to create skill folder for skill {skill_name} in agent {agent_name}")
+            return None
+
+        return skill_folder
+
+    def run_test(
+        self,
+        project_uuid,
+        definition,
+        skill_folder,
+        skill_name,
+        agent_name,
+        test_definition,
+        credentials,
+        skill_globals,
+        verbose=False,
+    ):
+        client = CLIClient()
+
+        client.run_test(
+            project_uuid,
+            definition,
+            skill_folder,
+            skill_name,
+            agent_name,
+            test_definition,
+            credentials,
+            skill_globals,
+            verbose,
+        )
+
+        click.echo(click.style("Test completed", fg="green"))

--- a/weni_cli/commands/run.py
+++ b/weni_cli/commands/run.py
@@ -85,9 +85,8 @@ class RunHandler(Handler):
         for _, data in definition.get("agents", {}).items():
             if data.get("name") == agent_name:
                 for skill in data.get("skills", []):
-                    for _, skill_data in skill.items():
-                        if skill_data.get("name") == skill_name:
-                            return skill_data.get("source", {}).get("path")
+                    if skill.get("name") == skill_name:
+                        return skill.get("source", {}).get("path")
         return None
 
     def load_skill_credentials(self, skill_source_path: str) -> dict | None:


### PR DESCRIPTION
Implement a new 'run' command in the CLI to execute tests for specific agent skills. This includes:
- Adding a new run command in cli.py
- Creating a RunHandler in commands/run.py to manage test execution
- Extending CLIClient with a run_test method to handle test running and progress display
- Supporting test definition loading, skill packaging, and credentials retrieval