### PR TITLE
feat: add project UUID header to CLI client requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-cli"
-version = "2.0.0a10"
+version = "2.0.0a11"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/tests/test_project_push.py
+++ b/tests/test_project_push.py
@@ -63,7 +63,9 @@ def test_project_push(mocker, **kwargs):
         create_mocked_files()
 
         # Mock the store values - project_uuid, token, and base_url
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 
@@ -90,7 +92,9 @@ def test_project_push_with_force_update(mocker, **kwargs):
         create_mocked_files()
 
         # Mock the store values - project_uuid, token, and base_url
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "--force-update", "agents.json"], terminal_width=80)
 
@@ -136,7 +140,9 @@ def test_project_push_error(mocker, **kwargs):
     with runner.isolated_filesystem():
         create_mocked_files()
 
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 
@@ -154,7 +160,9 @@ def test_project_push_invalid_definition(mocker, **kwargs):
         with open("agents.json", "w") as f:
             f.write('agents:\ntest: -123\n  name: "Jon Snow"')
 
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 
@@ -172,7 +180,9 @@ def test_project_push_empty_definition(mocker, **kwargs):
         with open("agents.json", "w") as f:
             f.write("")
 
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 
@@ -187,7 +197,9 @@ def test_project_push_missing_skill_file(mocker, **kwargs):
         with open("agents.json", "w") as f:
             f.write(SAMPLE_AGENT_DEFINITION_YAML)
 
-        mocker.patch("weni_cli.store.Store.get", side_effect=["123456", "456789", "https://cli.cloud.weni.ai"])
+        mocker.patch(
+            "weni_cli.store.Store.get", side_effect=["123456", "456789", "token", "https://cli.cloud.weni.ai"]
+        )
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 

--- a/weni_cli/clients/cli_client.py
+++ b/weni_cli/clients/cli_client.py
@@ -4,7 +4,7 @@ import json
 import importlib.metadata
 
 from weni_cli.spinner import spinner
-from weni_cli.store import STORE_CLI_BASE_URL, STORE_TOKEN_KEY, Store
+from weni_cli.store import STORE_CLI_BASE_URL, STORE_PROJECT_UUID_KEY, STORE_TOKEN_KEY, Store
 
 DEFAULT_BASE_URL = "https://cli.cloud.weni.ai"
 
@@ -30,7 +30,10 @@ class CLIClient:
 
     def __init__(self):
         store = Store()
-        self.headers = {"Authorization": f"Bearer {store.get(STORE_TOKEN_KEY)}"}
+        self.headers = {
+            "Authorization": f"Bearer {store.get(STORE_TOKEN_KEY)}",
+            "X-Project-Uuid": store.get(STORE_PROJECT_UUID_KEY),
+        }
         self.base_url = store.get(STORE_CLI_BASE_URL, DEFAULT_BASE_URL)
 
     def push_agents(self, project_uuid, agents_definition, skill_folders):


### PR DESCRIPTION
Enhance CLIClient to include project UUID in request headers:
- Add X-Project-Uuid header using stored project UUID
- Temporarily set base URL to localhost for development purposes