### PR TITLE
feat: update run command to use agent and skill keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-cli"
-version = "2.0.0a11"
+version = "2.0.0a12"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>"]
 readme = "README.md"

--- a/weni_cli/cli.py
+++ b/weni_cli/cli.py
@@ -28,24 +28,26 @@ def init():
 # Run Command
 @cli.command("run")
 @click.argument("definition", required=True, type=click.Path(exists=True, dir_okay=False))
-@click.argument("agent", required=True, type=str)
-@click.argument("skill", required=True, type=str)
+@click.argument("agent_key", required=True, type=str)
+@click.argument("skill_key", required=True, type=str)
 @click.option(
     "--file", "-f", help="The path to the test definition file", type=click.Path(exists=True, dir_okay=False)
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
-def run_test(definition, agent, skill, file, verbose):
+def run_test(definition, agent_key, skill_key, file, verbose):
     """Run tests for a specific agent skill
 
     DEFINITION: The path to the YAML agent definition file
-    AGENT: The agent name to be tested
-    SKILL: The skill name to be tested
+    AGENT_KEY: The agent key to be tested
+    SKILL_KEY: The skill key to be tested
     FILE: The path to the test definition file
     """
     from weni_cli.commands.run import RunHandler
 
     try:
-        RunHandler().execute(definition=definition, agent=agent, skill=skill, test_definition=file, verbose=verbose)
+        RunHandler().execute(
+            definition=definition, agent_key=agent_key, skill_key=skill_key, test_definition=file, verbose=verbose
+        )
     except Exception as e:
         click.echo(f"Error: {e}")
 

--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -41,6 +41,7 @@ def format_definition(definition):
                 skill_slug = slugify(skill_data.get("name"))
                 agent_skills.append(
                     {
+                        "key": skill_name,
                         "slug": skill_slug,
                         "name": skill_data.get("name"),
                         "source": skill_data.get("source"),


### PR DESCRIPTION
Modify run command and related handlers to support key-based skill and agent identification:
- Replace name-based lookups with key-based retrieval in RunHandler
- Update CLI command arguments to use agent_key and skill_key
- Add method to retrieve agent and skill names from keys
- Enhance definition parsing to include skill keys
- Improve error handling for key-based lookups