### PR TITLE
Add component validation to agent definition schema 

### DIFF
--- a/weni_cli/commands/project_push.py
+++ b/weni_cli/commands/project_push.py
@@ -29,7 +29,7 @@ class ProjectPushHandler(Handler):
 
         definition_data, error = load_agent_definition(definition_path)
         if error:
-            formatter.print_error_panel(error, title="Failed to load definition file")
+            formatter.print_error_panel(f"Invalid agent definition YAML file format, error:\n{error}", title="Failed to load definition file")
             return
 
         skills_folders_map, error = self.load_skills_folders(definition_data)

--- a/weni_cli/commands/run.py
+++ b/weni_cli/commands/run.py
@@ -39,7 +39,7 @@ class RunHandler(Handler):
 
         definition_data, error = load_agent_definition(definition_path)
         if error:
-            formatter.print_error_panel(error)
+            formatter.print_error_panel(f"Invalid agent definition YAML file format, error:\n{error}", title="Error loading agent definition")
             return
 
         if not test_definition_path:

--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -74,7 +74,9 @@ def validate_agent_definition_schema(data):
                 return f"Agent '{agent_key}': 'guardrails' must be an array in the agent definition file"
             for idx, guardrail in enumerate(agent_data["guardrails"]):
                 if not isinstance(guardrail, str):
-                    return f"Agent '{agent_key}': guardrail at index {idx} must be a string in the agent definition file"
+                    return (
+                        f"Agent '{agent_key}': guardrail at index {idx} must be a string in the agent definition file"
+                    )
                 if len(guardrail) < MIN_GUARDRAIL_LENGTH:
                     return f"Agent '{agent_key}': guardrail at index {idx} must have at least {MIN_GUARDRAIL_LENGTH} characters in the agent definition file"
 
@@ -85,7 +87,9 @@ def validate_agent_definition_schema(data):
 
             for idx, component in enumerate(agent_data["components"]):
                 if not isinstance(component, dict):
-                    return f"Agent '{agent_key}': component at index {idx} must be an object in the agent definition file"
+                    return (
+                        f"Agent '{agent_key}': component at index {idx} must be an object in the agent definition file"
+                    )
 
                 # Validate type (required, must be string)
                 if "type" not in component:
@@ -109,7 +113,9 @@ def validate_agent_definition_schema(data):
         # Validate each skill
         for skill_idx, skill_obj in enumerate(agent_data["skills"]):
             if not isinstance(skill_obj, dict):
-                return f"Agent '{agent_key}': skill at index {skill_idx} must be an object in the agent definition file"
+                return (
+                    f"Agent '{agent_key}': skill at index {skill_idx} must be an object in the agent definition file"
+                )
 
             # Each skill object should have one key that is the skill name
             if len(skill_obj) != 1:
@@ -126,7 +132,9 @@ def validate_agent_definition_schema(data):
             if not skill_data.get("name"):
                 return f"Agent '{agent_key}': skill '{skill_name}' is missing required field 'name' in the agent definition file"
             if not isinstance(skill_data["name"], str):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'name' must be a string in the agent definition file"
+                return (
+                    f"Agent '{agent_key}': skill '{skill_name}': 'name' must be a string in the agent definition file"
+                )
             if len(skill_data["name"]) > MAX_SKILL_NAME_LENGTH:
                 return f"Agent '{agent_key}': skill '{skill_name}': 'name' must be less than {MAX_SKILL_NAME_LENGTH} characters in the agent definition file"
 
@@ -156,9 +164,7 @@ def validate_agent_definition_schema(data):
                 return f"Agent '{agent_key}': skill '{skill_name}': 'source.entrypoint' must be a string in the agent definition file"
 
             # Validate source path_test if present (must be string)
-            if "path_test" in skill_data["source"] and not isinstance(
-                skill_data["source"]["path_test"], str
-            ):
+            if "path_test" in skill_data["source"] and not isinstance(skill_data["source"]["path_test"], str):
                 return f"Agent '{agent_key}': skill '{skill_name}': 'source.path_test' must be a string in the agent definition file"
 
             # Validate parameters if present
@@ -205,38 +211,22 @@ def validate_agent_definition_schema(data):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' type must be one of: string, number, integer, boolean, array in the agent definition file"
 
                     # Validate required if present (must be boolean)
-                    if "required" in param_data and not isinstance(
-                        param_data["required"], bool
-                    ):
+                    if "required" in param_data and not isinstance(param_data["required"], bool):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' required field must be a boolean in the agent definition file"
 
                     # Validate contact_field if present (must be boolean)
-                    if "contact_field" in param_data and not isinstance(
-                        param_data["contact_field"], bool
-                    ):
+                    if "contact_field" in param_data and not isinstance(param_data["contact_field"], bool):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' contact_field must be a boolean in the agent definition file"
 
                     # If contact_field is True, validate parameter name
 
-                    if param_data.get(
-                        "contact_field"
-                    ) and not ContactFieldValidator.has_valid_contact_field_name(
-                        param_name
-                    ):
+                    if param_data.get("contact_field") and not ContactFieldValidator.has_valid_contact_field_name(param_name):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must match the regex of a valid contact field: {re.escape(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX)} in the agent definition file"
 
-                    if param_data.get(
-                        "contact_field"
-                    ) and not ContactFieldValidator.has_valid_contact_field_length(
-                        param_name
-                    ):
+                    if param_data.get("contact_field") and not ContactFieldValidator.has_valid_contact_field_length(param_name):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must be {ContactFieldValidator.CONTACT_FIELD_MAX_LENGTH} characters or less in the agent definition file"
 
-                    if param_data.get(
-                        "contact_field"
-                    ) and not ContactFieldValidator.has_allowed_parameter_name(
-                        param_name
-                    ):
+                    if param_data.get("contact_field") and not ContactFieldValidator.has_allowed_parameter_name(param_name):
                         return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must not be a reserved contact field name in the agent definition file\nRestricted contact field names: {ContactFieldValidator.RESERVED_CONTACT_FIELDS}"
 
     return None
@@ -342,9 +332,7 @@ class ContactFieldValidator:
 
     @staticmethod
     def has_valid_contact_field_name(parameter_name) -> bool:
-        if not regex.match(
-            ContactFieldValidator.CONTACT_FIELD_NAME_REGEX, parameter_name, regex.V0
-        ):
+        if not regex.match(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX, parameter_name, regex.V0):
             return False
         return True
 

--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -8,7 +8,7 @@ from slugify import slugify
 MIN_INSTRUCTION_LENGTH = 40
 MIN_GUARDRAIL_LENGTH = 40
 MAX_AGENT_NAME_LENGTH = 55
-MAX_SKILL_NAME_LENGTH = 53
+MAX_SKILL_NAME_LENGTH = 40
 AVAILABLE_COMPONENTS = [
     "cta_message",
     "quick_replies",


### PR DESCRIPTION
- Introduced validation for the 'components' field in the agent definition schema, ensuring it is an array of objects.
- Added checks for the presence of a 'type' field in each component and validated that it matches predefined available component types.
- Implemented validation for the 'instructions' field within components, ensuring it is a string if present.
- Expanded test coverage to include various scenarios for component validation, ensuring robustness in error handling and schema compliance.