### PR TITLE
Enhance agent definition validation for credentials

### DIFF
--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -73,6 +73,32 @@ def validate_agent_definition_schema(data):
                 if len(guardrail) < MIN_GUARDRAIL_LENGTH:
                     return f"Agent '{agent_key}': guardrail at index {idx} must have at least {MIN_GUARDRAIL_LENGTH} characters in the agent definition file"
 
+        # Validate credentials if present (must be an object)
+        if "credentials" in agent_data:
+            if not isinstance(agent_data["credentials"], dict):
+                return f"Agent '{agent_key}': 'credentials' must be an object in the agent definition file"
+
+            # Validate each credential (must be an object)
+            for credential_key, credential_value in agent_data["credentials"].items():
+                if not isinstance(credential_value, dict):
+                    return f"Agent '{agent_key}': value for credential '{credential_key}' must be an object in the agent definition file"
+
+                # Validate label (required, must be a string)
+                if not credential_value.get("label"):
+                    return f"Agent '{agent_key}': 'label' for credential '{credential_key}' is missing in the agent definition file"
+                if not isinstance(credential_value["label"], str):
+                    return f"Agent '{agent_key}': 'label' for credential '{credential_key}' must be a string in the agent definition file"
+
+                # Validate placeholder (required, must be a string)
+                if not credential_value.get("placeholder"):
+                    return f"Agent '{agent_key}': 'placeholder' for credential '{credential_key}' is missing in the agent definition file"
+                if not isinstance(credential_value["placeholder"], str):
+                    return f"Agent '{agent_key}': 'placeholder' for credential '{credential_key}' must be a string in the agent definition file"
+
+                # Validate is_confidential if present (must be a boolean)
+                if "is_confidential" in credential_value and not isinstance(credential_value["is_confidential"], bool):
+                    return f"Agent '{agent_key}': 'is_confidential' for credential '{credential_key}' must be a boolean in the agent definition file"
+
         # Validate skills
         if not agent_data.get("skills"):
             return f"Agent '{agent_key}' is missing required field 'skills' in the agent definition file"
@@ -237,7 +263,6 @@ def format_definition(definition: dict) -> Optional[dict]:
         agent_skills = []
         for skill in skills:
             for skill_name, skill_data in skill.items():
-
                 skill_slug = slugify(skill_data.get("name"))
                 agent_skills.append(
                     {

--- a/weni_cli/validators/tests/test_definition.py
+++ b/weni_cli/validators/tests/test_definition.py
@@ -468,25 +468,13 @@ def test_validate_definition_with_invalid_guardrails():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": "Not an array",  # String instead of array
-                "skills": [
-                    {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
-                            "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
-                            },
-                        }
-                    }
-                ],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "'guardrails' must be an array" in error
+    assert "Agent 'test_agent': 'guardrails' must be an array in the agent definition file" in error
 
 
 def test_validate_definition_with_invalid_agent_data():
@@ -836,7 +824,8 @@ def test_validate_definition_with_missing_skill_source():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1' is missing required field 'source' in the agent definition file" in error
+        "Agent 'test_agent': skill 'skill_1' is missing required field 'source' in the agent definition file"
+        in error
     )
 
 
@@ -1590,3 +1579,272 @@ def test_load_test_definition_passes_correct_path(mocker):
 
     # Verify that load_yaml_file was called with the correct path
     mock_load_yaml.assert_called_once_with(test_path)
+
+
+def test_validate_definition_with_valid_credentials():
+    """Test validation passes when credentials are valid."""
+    valid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        "label": "API Key",
+                        "placeholder": "Enter your API key",
+                        "is_confidential": True
+                    },
+                    "username": {
+                        "label": "Username",
+                        "placeholder": "Enter your username"
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(valid_definition)
+    assert error is None
+
+
+def test_validate_definition_with_invalid_credentials_type():
+    """Test validation fails when credentials is not an object."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": "Not an object",  # String instead of object
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'credentials' must be an object in the agent definition file" in error
+
+
+def test_validate_definition_with_invalid_credential_value_type():
+    """Test validation fails when credential value is not an object."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": "Not an object"  # String instead of object
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': value for credential 'api_key' must be an object in the agent definition file" in error
+
+
+def test_validate_definition_with_missing_credential_label():
+    """Test validation fails when credential label is missing."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        # No label
+                        "placeholder": "Enter your API key"
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'label' for credential 'api_key' is missing in the agent definition file" in error
+
+
+def test_validate_definition_with_invalid_credential_label_type():
+    """Test validation fails when credential label is not a string."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        "label": 123,  # Number instead of string
+                        "placeholder": "Enter your API key"
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'label' for credential 'api_key' must be a string in the agent definition file" in error
+
+
+def test_validate_definition_with_missing_credential_placeholder():
+    """Test validation fails when credential placeholder is missing."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        "label": "API Key",
+                        # No placeholder
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'placeholder' for credential 'api_key' is missing in the agent definition file" in error
+
+
+def test_validate_definition_with_invalid_credential_placeholder_type():
+    """Test validation fails when credential placeholder is not a string."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        "label": "API Key",
+                        "placeholder": 123  # Number instead of string
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'placeholder' for credential 'api_key' must be a string in the agent definition file" in error
+
+
+def test_validate_definition_with_invalid_credential_is_confidential_type():
+    """Test validation fails when credential is_confidential is not a boolean."""
+    invalid_definition = {
+        "agents": {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "Test description",
+                "credentials": {
+                    "api_key": {
+                        "label": "API Key",
+                        "placeholder": "Enter your API key",
+                        "is_confidential": "true"  # String instead of boolean
+                    }
+                },
+                "skills": [
+                    {
+                        "test_skill": {
+                            "name": "Test Skill",
+                            "description": "Test skill description",
+                            "source": {
+                                "path": "skills/test",
+                                "entrypoint": "main.TestSkill",
+                            },
+                        }
+                    }
+                ],
+            }
+        }
+    }
+
+    error = validate_agent_definition_schema(invalid_definition)
+    assert error is not None
+    assert "Agent 'test_agent': 'is_confidential' for credential 'api_key' must be a boolean in the agent definition file" in error


### PR DESCRIPTION
- Added validation for the 'credentials' field to ensure it is an object.
- Implemented checks for each credential to verify it is an object, and that required fields 'label' and 'placeholder' are present and of the correct type.
- Included validation for the optional 'is_confidential' field to ensure it is a boolean.
- Updated tests to cover various scenarios for valid and invalid credentials, improving overall validation robustness.