### PR TITLE
Refactor agent definition to replace 'skills' with 'tools'

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from weni_cli.cli import init
 from weni_cli.commands.init import (
     SAMPLE_AGENT_DEFINITION_FILE_NAME,
-    SKILLS_FOLDER,
-    SAMPLE_GET_ADDRESS_SKILL_NAME,
+    TOOLS_FOLDER,
+    SAMPLE_GET_ADDRESS_TOOL_NAME,
     DEFAULT_TEST_DEFINITION_FILE,
     SAMPLE_AGENT_DEFINITION_YAML,
-    SAMPLE_GET_ADDRESS_SKILL_PY,
+    SAMPLE_GET_ADDRESS_TOOL_PY,
     SAMPLE_TESTS_YAML,
     SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT,
 )
@@ -46,21 +46,21 @@ def test_init_command_creates_agent_definition_file(cli_runner):
     assert f"Sample agent definition file created in: {SAMPLE_AGENT_DEFINITION_FILE_NAME}" in result.output
 
 
-def test_init_command_creates_skill_files(cli_runner):
-    """Test that the init command creates the skill files."""
+def test_init_command_creates_tool_files(cli_runner):
+    """Test that the init command creates the tool files."""
     result = cli_runner.invoke(init)
 
     # Check main.py
-    skill_file = Path(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}/main.py")
-    assert skill_file.exists(), f"Skill file not created: {skill_file}"
+    tool_file = Path(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}/main.py")
+    assert tool_file.exists(), f"Tool file not created: {tool_file}"
 
     # Check content of main.py
-    with open(skill_file, "r") as f:
+    with open(tool_file, "r") as f:
         content = f.read()
-    assert content == SAMPLE_GET_ADDRESS_SKILL_PY, "Skill file has incorrect content"
+    assert content == SAMPLE_GET_ADDRESS_TOOL_PY, "Tool file has incorrect content"
 
     # Check requirements.txt
-    requirements_file = Path(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}/requirements.txt")
+    requirements_file = Path(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}/requirements.txt")
     assert requirements_file.exists(), f"Requirements file not created: {requirements_file}"
 
     # Check content of requirements.txt
@@ -69,8 +69,8 @@ def test_init_command_creates_skill_files(cli_runner):
     assert content == SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT, "Requirements file has incorrect content"
 
     # Check output messages
-    assert f"Sample skill {SAMPLE_GET_ADDRESS_SKILL_NAME} created in:" in result.output
-    assert f"Sample requirements file for {SAMPLE_GET_ADDRESS_SKILL_NAME} created in:" in result.output
+    assert f"Sample tool {SAMPLE_GET_ADDRESS_TOOL_NAME} created in:" in result.output
+    assert f"Sample requirements file for {SAMPLE_GET_ADDRESS_TOOL_NAME} created in:" in result.output
 
 
 def test_init_command_creates_test_files(cli_runner):
@@ -78,7 +78,7 @@ def test_init_command_creates_test_files(cli_runner):
     result = cli_runner.invoke(init)
 
     # Check test file
-    test_file = Path(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}/{DEFAULT_TEST_DEFINITION_FILE}")
+    test_file = Path(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}/{DEFAULT_TEST_DEFINITION_FILE}")
     assert test_file.exists(), f"Test file not created: {test_file}"
 
     # Check content of test file
@@ -87,20 +87,20 @@ def test_init_command_creates_test_files(cli_runner):
     assert content == SAMPLE_TESTS_YAML, "Test file has incorrect content"
 
     # Check output message
-    assert f"Sample tests file for {SAMPLE_GET_ADDRESS_SKILL_NAME} created in:" in result.output
+    assert f"Sample tests file for {SAMPLE_GET_ADDRESS_TOOL_NAME} created in:" in result.output
 
 
 def test_init_command_creates_required_directories(cli_runner):
     """Test that the init command creates all required directories."""
     cli_runner.invoke(init)
 
-    # Check skills directory
-    skills_dir = Path(SKILLS_FOLDER)
-    assert skills_dir.exists() and skills_dir.is_dir(), f"Skills directory not created: {skills_dir}"
+    # Check tools directory
+    tools_dir = Path(TOOLS_FOLDER)
+    assert tools_dir.exists() and tools_dir.is_dir(), f"Tools directory not created: {tools_dir}"
 
-    # Check skill-specific directory
-    skill_dir = Path(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}")
-    assert skill_dir.exists() and skill_dir.is_dir(), f"Skill directory not created: {skill_dir}"
+    # Check tool-specific directory
+    tool_dir = Path(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}")
+    assert tool_dir.exists() and tool_dir.is_dir(), f"Tool directory not created: {tool_dir}"
 
 
 def test_init_ensure_directory_error(cli_runner, mocker):

--- a/tests/test_project_push.py
+++ b/tests/test_project_push.py
@@ -8,10 +8,10 @@ from click.testing import CliRunner
 from weni_cli.cli import project
 from weni_cli.commands.init import (
     SAMPLE_AGENT_DEFINITION_YAML,
-    SAMPLE_GET_ADDRESS_SKILL_NAME,
-    SAMPLE_GET_ADDRESS_SKILL_PY,
+    SAMPLE_GET_ADDRESS_TOOL_NAME,
+    SAMPLE_GET_ADDRESS_TOOL_PY,
     SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT,
-    SKILLS_FOLDER,
+    TOOLS_FOLDER,
 )
 
 
@@ -35,18 +35,18 @@ def create_mocked_files():
         with open("agents.json", "w") as f:
             f.write(SAMPLE_AGENT_DEFINITION_YAML)
 
-        # Create skill directories
+        # Create tool directories
         try:
-            os.mkdir(SKILLS_FOLDER)
-            os.mkdir(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}")
+            os.mkdir(TOOLS_FOLDER)
+            os.mkdir(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}")
         except FileExistsError:
             pass
 
-        # Write skill files
-        with open(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}/main.py", "w") as f:
-            f.write(SAMPLE_GET_ADDRESS_SKILL_PY)
+        # Write tool files
+        with open(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}/main.py", "w") as f:
+            f.write(SAMPLE_GET_ADDRESS_TOOL_PY)
 
-        with open(f"{SKILLS_FOLDER}/{SAMPLE_GET_ADDRESS_SKILL_NAME}/requirements.txt", "w") as f:
+        with open(f"{TOOLS_FOLDER}/{SAMPLE_GET_ADDRESS_TOOL_NAME}/requirements.txt", "w") as f:
             f.write(SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT)
 
     return _create
@@ -210,18 +210,18 @@ def test_project_push_empty_definition(mocker, mock_store_values, **kwargs):
 
 
 @requests_mock.Mocker(kw="requests_mock")
-def test_project_push_missing_skill_file(mocker, mock_store_values, **kwargs):
-    """Test that missing skill folders are properly handled."""
+def test_project_push_missing_tool_file(mocker, mock_store_values, **kwargs):
+    """Test that missing tool folders are properly handled."""
     mock_store_values(mocker)
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create definition but don't create the skill folder
+        # Create definition but don't create the tool folder
         with open("agents.json", "w") as f:
             f.write(SAMPLE_AGENT_DEFINITION_YAML)
 
         result = runner.invoke(project, ["push", "agents.json"], terminal_width=80)
 
         assert result.exit_code == 0
-        assert "Failed to create skill folder for skill Get Address in agent CEP Agent" in result.output
-        assert "Folder skills/get_address not found" in result.output
+        assert "Failed to create tool folder for tool Get Address in agent CEP Agent" in result.output
+        assert "Folder tools/get_address not found" in result.output

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -27,14 +27,14 @@ agents:
   get_address:
     name: Get Address
     description: An agent to get address information
-    skills:
+    tools:
       - get_address:
           name: Get Address
-          description: A skill to get address information
+          description: A tool to get address information
           source:
-            path: skills/get_address
+            path: tools/get_address
             path_test: test_definition.yaml
-            entrypoint: main.Skill
+            entrypoint: main.Tool
           parameters:
             - address:
                 type: string
@@ -43,14 +43,14 @@ agents:
             """
             )
 
-        # Create skill directories
+        # Create tool directories
         try:
-            os.makedirs("skills/get_address", exist_ok=True)
+            os.makedirs("tools/get_address", exist_ok=True)
         except Exception:
             pass
 
         # Create test definition
-        with open("skills/get_address/test_definition.yaml", "w") as f:
+        with open("tools/get_address/test_definition.yaml", "w") as f:
             f.write(
                 """
 test_cases:
@@ -60,8 +60,8 @@ test_cases:
             """
             )
 
-        # Create skill file
-        with open("skills/get_address/skill.py", "w") as f:
+        # Create tool file
+        with open("tools/get_address/tool.py", "w") as f:
             f.write(
                 """
 def run(input, context):
@@ -70,10 +70,10 @@ def run(input, context):
             )
 
         # Create empty credentials and globals files
-        with open("skills/get_address/.env", "w") as f:
+        with open("tools/get_address/.env", "w") as f:
             f.write("API_KEY=sample_key\n")
 
-        with open("skills/get_address/.globals", "w") as f:
+        with open("tools/get_address/.globals", "w") as f:
             f.write("REGION=us-east-1\n")
 
         return "agents.yaml"
@@ -142,41 +142,41 @@ def mock_store_values():
 
 
 @pytest.fixture
-def mock_skill_folder():
-    """Mock the skill folder creation."""
+def mock_tool_folder():
+    """Mock the tool folder creation."""
 
     def _mock(mocker):
-        mock_zip = mocker.patch("weni_cli.packager.packager.create_skill_folder_zip")
+        mock_zip = mocker.patch("weni_cli.packager.packager.create_tool_folder_zip")
         mock_zip.return_value = io.BytesIO(b"mock zip content")
         return mock_zip
 
     return _mock
 
 
-def test_run_command_success(mocker, create_mocked_files, mock_cli_response, mock_store_values, mock_skill_folder):
-    """Test running a skill test successfully."""
+def test_run_command_success(mocker, create_mocked_files, mock_cli_response, mock_store_values, mock_tool_folder):
+    """Test running a tool test successfully."""
 
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         mock_store_values(mocker)
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
         mock_cli_response(mocker)
 
         # Mock the methods directly
         mocker.patch(
             "weni_cli.commands.run.RunHandler.load_default_test_definition",
-            return_value=f"skills/get_address/{DEFAULT_TEST_DEFINITION_FILE}",
+            return_value=f"tools/get_address/{DEFAULT_TEST_DEFINITION_FILE}",
         )
         mocker.patch(
-            "weni_cli.commands.run.RunHandler.load_skill_folder", return_value=(io.BytesIO(b"mock zip content"), None)
+            "weni_cli.commands.run.RunHandler.load_tool_folder", return_value=(io.BytesIO(b"mock zip content"), None)
         )
-        mocker.patch("weni_cli.commands.run.RunHandler.get_skill_source_path", return_value="skills/get_address")
-        mocker.patch("weni_cli.commands.run.RunHandler.load_skill_credentials", return_value={"API_KEY": "test_key"})
-        mocker.patch("weni_cli.commands.run.RunHandler.load_skill_globals", return_value={"REGION": "us-east-1"})
+        mocker.patch("weni_cli.commands.run.RunHandler.get_tool_source_path", return_value="tools/get_address")
+        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_credentials", return_value={"API_KEY": "test_key"})
+        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_globals", return_value={"REGION": "us-east-1"})
         mocker.patch(
-            "weni_cli.commands.run.RunHandler.get_skill_and_agent_name",
-            return_value=("Get Address", "Get Address Skill"),
+            "weni_cli.commands.run.RunHandler.get_tool_and_agent_name",
+            return_value=("Get Address", "Get Address Tool"),
         )
 
         # Mock the CLIClient.run_test before the test
@@ -218,21 +218,21 @@ def test_run_handler_execute_no_project(mocker, mock_store_values):
         result = handler.execute(
             definition="agents.yaml",
             agent_key="get_address",
-            skill_key="get_address",
+            tool_key="get_address",
         )
 
         assert result is None
 
 
 def test_run_command_with_external_test_file(
-    mocker, create_mocked_files, mock_cli_response, mock_store_values, mock_skill_folder
+    mocker, create_mocked_files, mock_cli_response, mock_store_values, mock_tool_folder
 ):
-    """Test running a skill test with an external test definition file."""
+    """Test running a tool test with an external test definition file."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
         mock_cli_response(mocker)
 
         # Create an external test file
@@ -284,21 +284,21 @@ def test_run_command_missing_definition(mocker, mock_store_values):
         assert "does not exist" in result.output
 
 
-def test_run_command_missing_test_definition(mocker, create_mocked_files, mock_store_values, mock_skill_folder):
+def test_run_command_missing_test_definition(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
     """Test running a command with a missing test definition file."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
 
         # Remove the test definition file
-        os.remove("skills/get_address/test_definition.yaml")
+        os.remove("tools/get_address/test_definition.yaml")
 
         # Mock load_agent_definition to return valid data
         mocker.patch(
             "weni_cli.commands.run.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "skills": []}}}, None),
+            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
         )
 
         # Patch the load_default_test_definition to return None
@@ -312,8 +312,8 @@ def test_run_command_missing_test_definition(mocker, create_mocked_files, mock_s
         assert "Failed to get default test definition file" in result.output
 
 
-def test_run_command_skill_folder_failure(mocker, create_mocked_files, mock_store_values):
-    """Test running a command when skill folder creation fails."""
+def test_run_command_tool_folder_failure(mocker, create_mocked_files, mock_store_values):
+    """Test running a command when tool folder creation fails."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
@@ -322,37 +322,37 @@ def test_run_command_skill_folder_failure(mocker, create_mocked_files, mock_stor
         # Mock load_agent_definition to return valid data
         mocker.patch(
             "weni_cli.commands.run.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "skills": []}}}, None),
+            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
         )
 
         # Patch the load_default_test_definition to return a valid file
         mocker.patch(
             "weni_cli.commands.run.RunHandler.load_default_test_definition",
-            return_value="skills/get_address/test_definition.yaml",
+            return_value="tools/get_address/test_definition.yaml",
         )
 
-        # Patch the load_skill_folder to return None
-        mocker.patch("weni_cli.commands.run.RunHandler.load_skill_folder", return_value=(None, "Failed to load skill folder"))
+        # Patch the load_tool_folder to return None
+        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_folder", return_value=(None, "Failed to load tool folder"))
 
         result = runner.invoke(cli, ["run", agent_file, "get_address", "get_address"])
 
         assert result.exit_code == 0
         # Check the output directly for the error message
-        assert "Failed to load skill folder" in result.output
+        assert "Failed to load tool folder" in result.output
 
 
-def test_run_command_skill_name_error(mocker, create_mocked_files, mock_store_values, mock_skill_folder):
-    """Test running a command when get_skill_and_agent_name returns None."""
+def test_run_command_tool_name_error(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
+    """Test running a command when get_tool_and_agent_name returns None."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
 
         # Mock load_agent_definition to return valid data
         mocker.patch(
             "weni_cli.commands.run.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "skills": []}}}, None),
+            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
         )
 
         # Mock load_test_definition to return valid data
@@ -361,39 +361,39 @@ def test_run_command_skill_name_error(mocker, create_mocked_files, mock_store_va
         # Patch the load_default_test_definition to return a valid file
         mocker.patch(
             "weni_cli.commands.run.RunHandler.load_default_test_definition",
-            return_value="skills/get_address/test_definition.yaml",
+            return_value="tools/get_address/test_definition.yaml",
         )
 
-        # Patch the load_skill_folder to return a mock folder
-        mocker.patch("weni_cli.commands.run.RunHandler.load_skill_folder", return_value=(b"mock_skill_folder", None))
+        # Patch the load_tool_folder to return a mock folder
+        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_folder", return_value=(b"mock_tool_folder", None))
 
         # Make sure format_definition returns a valid definition
         mocker.patch(
-            "weni_cli.commands.run.format_definition", return_value={"agents": {"get_address": {"skills": []}}}
+            "weni_cli.commands.run.format_definition", return_value={"agents": {"get_address": {"tools": []}}}
         )
 
-        # Patch the get_skill_and_agent_name to return None
-        mocker.patch("weni_cli.commands.run.RunHandler.get_skill_and_agent_name", return_value=(None, None))
+        # Patch the get_tool_and_agent_name to return None
+        mocker.patch("weni_cli.commands.run.RunHandler.get_tool_and_agent_name", return_value=(None, None))
 
         result = runner.invoke(cli, ["run", agent_file, "get_address", "get_address"])
 
         assert result.exit_code == 0
         # Check the output directly for the error message
-        assert "Failed to get skill or agent name" in result.output
+        assert "Failed to get tool or agent name" in result.output
 
 
-def test_run_command_invalid_test_definition(mocker, create_mocked_files, mock_store_values, mock_skill_folder):
+def test_run_command_invalid_test_definition(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
     """Test running a command when test definition file is invalid."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
 
         # Mock load_agent_definition to return valid data
         mocker.patch(
             "weni_cli.commands.run.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "skills": []}}}, None),
+            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
         )
 
         # Mock load_test_definition to return an error
@@ -403,15 +403,15 @@ def test_run_command_invalid_test_definition(mocker, create_mocked_files, mock_s
         # Patch the load_default_test_definition to return a valid file
         mocker.patch(
             "weni_cli.commands.run.RunHandler.load_default_test_definition",
-            return_value="skills/get_address/test_definition.yaml",
+            return_value="tools/get_address/test_definition.yaml",
         )
 
-        # Patch the load_skill_folder to return a mock folder
-        mocker.patch("weni_cli.commands.run.RunHandler.load_skill_folder", return_value=(b"mock_skill_folder", None))
+        # Patch the load_tool_folder to return a mock folder
+        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_folder", return_value=(b"mock_tool_folder", None))
 
         # Patch the format_definition to return a valid definition
         mocker.patch(
-            "weni_cli.commands.run.format_definition", return_value=({"agents": {"get_address": {"skills": []}}}, None)
+            "weni_cli.commands.run.format_definition", return_value=({"agents": {"get_address": {"tools": []}}}, None)
         )
 
         result = runner.invoke(cli, ["run", agent_file, "get_address", "get_address"])
@@ -422,100 +422,101 @@ def test_run_command_invalid_test_definition(mocker, create_mocked_files, mock_s
         assert error_message in result.output
 
 
-def test_parse_agent_skill_success():
-    """Test parse_agent_skill with valid input."""
+def test_parse_agent_tool_success():
+    """Test parse_agent_tool with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        agent_key, skill_key = handler.parse_agent_skill("get_address.get_address")
+        agent_key, tool_key = handler.parse_agent_tool("get_address.get_address")
         assert agent_key == "get_address"
-        assert skill_key == "get_address"
+        assert tool_key == "get_address"
 
 
-def test_parse_agent_skill_failure():
-    """Test parse_agent_skill with invalid input."""
+def test_parse_agent_tool_failure():
+    """Test parse_agent_tool with invalid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        agent_key, skill_key = handler.parse_agent_skill("invalid_format")
+        agent_key, tool_key = handler.parse_agent_tool("invalid_format")
         assert agent_key is None
-        assert skill_key is None
+        assert tool_key is None
 
 
-def test_get_skill_and_agent_name_success():
-    """Test get_skill_and_agent_name with valid input."""
+def test_get_tool_and_agent_name_success():
+    """Test get_tool_and_agent_name with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        # This sample definition is actually not used in the test, as we're using
-        # the correctly formatted test definition below
-        _ = {
-            "agents": {
-                "get_address": {"name": "Get Address", "skills": [{"get_address": {"name": "Get Address Skill"}}]}
-            }
-        }
 
         # Mock the definition to match our expected structure
         formatted_definition = {
             "agents": {
-                "get_address": {"name": "Get Address", "skills": [{"key": "get_address", "name": "Get Address Skill"}]}
+                "get_address": {
+                    "name": "Get Address",
+                    "tools": [
+                        {
+                            "name": "Get Address Tool",
+                            "key": "get_address"
+                        }
+                    ]
+                }
             }
         }
 
-        agent_name, skill_name = handler.get_skill_and_agent_name(formatted_definition, "get_address", "get_address")
+        agent_name, tool_name = handler.get_tool_and_agent_name(formatted_definition, "get_address", "get_address")
         assert agent_name == "Get Address"
-        assert skill_name == "Get Address Skill"
+        assert tool_name == "Get Address Tool"
 
 
-def test_get_skill_and_agent_name_failure():
-    """Test get_skill_and_agent_name with invalid input."""
+def test_get_tool_and_agent_name_failure():
+    """Test get_tool_and_agent_name with invalid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {"agents": {}}
-        agent_name, skill_name = handler.get_skill_and_agent_name(definition, "nonexistent", "nonexistent")
+        agent_name, tool_name = handler.get_tool_and_agent_name(definition, "nonexistent", "nonexistent")
         assert agent_name is None
-        assert skill_name is None
+        assert tool_name is None
 
 
-def test_get_skill_source_path_success():
-    """Test get_skill_source_path with valid input."""
+def test_get_tool_source_path_success():
+    """Test get_tool_source_path with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {
-            "agents": {"get_address": {"skills": [{"key": "get_address", "source": {"path": "skills/get_address"}}]}}
+            "agents": {"get_address": {"tools": [{"key": "get_address", "source": {"path": "tools/get_address"}}]}}
         }
-        path = handler.get_skill_source_path(definition, "get_address", "get_address")
-        assert path == "skills/get_address"
+        path = handler.get_tool_source_path(definition, "get_address", "get_address")
+        assert path == "tools/get_address"
 
 
-def test_get_skill_source_path_failure():
-    """Test get_skill_source_path with invalid input."""
+def test_get_tool_source_path_failure():
+    """Test get_tool_source_path with invalid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {"agents": {}}
-        path = handler.get_skill_source_path(definition, "nonexistent", "nonexistent")
+        path = handler.get_tool_source_path(definition, "nonexistent", "nonexistent")
         assert path is None
 
 
-def test_get_skill_source_path_agent_exists_but_skill_not_found():
-    """Test get_skill_source_path when agent exists but skill is not found."""
+def test_get_tool_source_path_agent_exists_but_tool_not_found():
+    """Test get_tool_source_path when agent exists but tool is not found."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {
             "agents": {
-                "get_address": {"skills": [{"key": "different_skill", "source": {"path": "skills/different_skill"}}]}
+                "get_address": {"tools": [{"key": "different_tool", "source": {"path": "tools/different_tool"}}]}
             }
         }
-        result = handler.get_skill_source_path(definition, "get_address", "get_address")
+        result = handler.get_tool_source_path(definition, "get_address", "get_address")
         assert result is None
 
 
-def test_load_skill_credentials_success(mocker):
-    """Test load_skill_credentials with valid input."""
+def test_load_tool_credentials_success(mocker):
+    """Test load_tool_credentials with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -523,13 +524,13 @@ def test_load_skill_credentials_success(mocker):
         # Mock the open function to return a file with credentials
         mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data="API_KEY=test_key\nSECRET=test_secret\n"))
 
-        credentials = handler.load_skill_credentials("path/to/skill")
+        credentials = handler.load_tool_credentials("path/to/tool")
         assert credentials == {"API_KEY": "test_key", "SECRET": "test_secret"}
-        mock_open.assert_called_once_with("path/to/skill/.env", "r")
+        mock_open.assert_called_once_with("path/to/tool/.env", "r")
 
 
-def test_load_skill_credentials_failure(mocker):
-    """Test load_skill_credentials when file doesn't exist."""
+def test_load_tool_credentials_failure(mocker):
+    """Test load_tool_credentials when file doesn't exist."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -537,13 +538,13 @@ def test_load_skill_credentials_failure(mocker):
         # Mock the open function to raise an exception
         mock_open = mocker.patch("builtins.open", side_effect=FileNotFoundError)
 
-        credentials = handler.load_skill_credentials("path/to/skill")
+        credentials = handler.load_tool_credentials("path/to/tool")
         assert credentials == {}
-        mock_open.assert_called_once_with("path/to/skill/.env", "r")
+        mock_open.assert_called_once_with("path/to/tool/.env", "r")
 
 
-def test_load_skill_globals_success(mocker):
-    """Test load_skill_globals with valid input."""
+def test_load_tool_globals_success(mocker):
+    """Test load_tool_globals with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -551,13 +552,13 @@ def test_load_skill_globals_success(mocker):
         # Mock the open function to return a file with globals
         mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data="REGION=us-east-1\nLANGUAGE=en\n"))
 
-        globals_dict = handler.load_skill_globals("path/to/skill")
+        globals_dict = handler.load_tool_globals("path/to/tool")
         assert globals_dict == {"REGION": "us-east-1", "LANGUAGE": "en"}
-        mock_open.assert_called_once_with("path/to/skill/.globals", "r")
+        mock_open.assert_called_once_with("path/to/tool/.globals", "r")
 
 
-def test_load_skill_globals_failure(mocker):
-    """Test load_skill_globals when file doesn't exist."""
+def test_load_tool_globals_failure(mocker):
+    """Test load_tool_globals when file doesn't exist."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -565,9 +566,9 @@ def test_load_skill_globals_failure(mocker):
         # Mock the open function to raise an exception
         mock_open = mocker.patch("builtins.open", side_effect=FileNotFoundError)
 
-        globals_dict = handler.load_skill_globals("path/to/skill")
+        globals_dict = handler.load_tool_globals("path/to/tool")
         assert globals_dict == {}
-        mock_open.assert_called_once_with("path/to/skill/.globals", "r")
+        mock_open.assert_called_once_with("path/to/tool/.globals", "r")
 
 
 def test_load_default_test_definition_success():
@@ -578,14 +579,14 @@ def test_load_default_test_definition_success():
         definition = {
             "agents": {
                 "get_address": {
-                    "skills": [
-                        {"get_address": {"source": {"path": "skills/get_address", "path_test": "custom_test.yaml"}}}
+                    "tools": [
+                        {"get_address": {"source": {"path": "tools/get_address", "path_test": "custom_test.yaml"}}}
                     ]
                 }
             }
         }
         path = handler.load_default_test_definition(definition, "get_address", "get_address")
-        assert path == "skills/get_address/custom_test.yaml"
+        assert path == "tools/get_address/custom_test.yaml"
 
 
 def test_load_default_test_definition_no_path_test():
@@ -594,10 +595,10 @@ def test_load_default_test_definition_no_path_test():
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {
-            "agents": {"get_address": {"skills": [{"get_address": {"source": {"path": "skills/get_address"}}}]}}
+            "agents": {"get_address": {"tools": [{"get_address": {"source": {"path": "tools/get_address"}}}]}}
         }
         path = handler.load_default_test_definition(definition, "get_address", "get_address")
-        assert path == f"skills/get_address/{DEFAULT_TEST_DEFINITION_FILE}"
+        assert path == f"tools/get_address/{DEFAULT_TEST_DEFINITION_FILE}"
 
 
 def test_load_default_test_definition_failure():
@@ -610,51 +611,51 @@ def test_load_default_test_definition_failure():
         assert path is None
 
 
-def test_load_skill_folder_success(mocker, create_mocked_files):
-    """Test load_skill_folder with valid input."""
+def test_load_tool_folder_success(mocker, create_mocked_files):
+    """Test load_tool_folder with valid input."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         create_mocked_files()
         handler = RunHandler()
 
-        # Mock create_skill_folder_zip to return a bytesIO object
-        mock_zip = mocker.patch("weni_cli.commands.run.create_skill_folder_zip")
+        # Mock create_tool_folder_zip to return a bytesIO object
+        mock_zip = mocker.patch("weni_cli.commands.run.create_tool_folder_zip")
         mock_zip.return_value = (io.BytesIO(b"mock zip content"), None)
 
         definition = {
             "agents": {
                 "get_address": {
-                    "skills": [{"get_address": {"name": "Get Address", "source": {"path": "skills/get_address"}}}]
+                    "tools": [{"get_address": {"name": "Get Address", "source": {"path": "tools/get_address"}}}]
                 }
             }
         }
 
-        result, error = handler.load_skill_folder(definition, "get_address", "get_address")
+        result, error = handler.load_tool_folder(definition, "get_address", "get_address")
         assert result is not None
         assert error is None
-        mock_zip.assert_called_once_with("get-address", "skills/get_address")
+        mock_zip.assert_called_once_with("get-address", "tools/get_address")
 
 
-def test_load_skill_folder_agent_not_found():
-    """Test load_skill_folder when agent is not found."""
+def test_load_tool_folder_agent_not_found():
+    """Test load_tool_folder when agent is not found."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         definition = {"agents": {}}
-        result, error = handler.load_skill_folder(definition, "nonexistent", "get_address")
+        result, error = handler.load_tool_folder(definition, "nonexistent", "get_address")
         assert result is None
         assert "Agent nonexistent not found in definition" in str(error)
 
 
-def test_load_skill_folder_skill_not_found():
-    """Test load_skill_folder when skill is not found."""
+def test_load_tool_folder_tool_not_found():
+    """Test load_tool_folder when tool is not found."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        definition = {"agents": {"get_address": {"skills": []}}}
-        result, error = handler.load_skill_folder(definition, "get_address", "nonexistent")
+        definition = {"agents": {"get_address": {"tools": []}}}
+        result, error = handler.load_tool_folder(definition, "get_address", "nonexistent")
         assert result is None
-        assert "Skill nonexistent not found in agent get_address" in str(error)
+        assert "Tool nonexistent not found in agent get_address" in str(error)
 
 
 def test_format_response_for_display_none():
@@ -717,8 +718,8 @@ def test_get_status_icon_failure():
     assert icon == "❌"
 
 
-def test_load_skill_credentials_with_malformed_data(mocker):
-    """Test load_skill_credentials when the file contains malformed data."""
+def test_load_tool_credentials_with_malformed_data(mocker):
+    """Test load_tool_credentials when the file contains malformed data."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -727,9 +728,9 @@ def test_load_skill_credentials_with_malformed_data(mocker):
         mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data="API_KEY:test_key\nSECRET=test_secret\n"))
 
         # Should throw an exception that gets caught, returning empty dict
-        credentials = handler.load_skill_credentials("path/to/skill")
+        credentials = handler.load_tool_credentials("path/to/tool")
         assert credentials == {}
-        mock_open.assert_called_once_with("path/to/skill/.env", "r")
+        mock_open.assert_called_once_with("path/to/tool/.env", "r")
 
 
 def test_load_default_test_definition_exception_handling(mocker):
@@ -742,7 +743,7 @@ def test_load_default_test_definition_exception_handling(mocker):
         definition = {
             "agents": {
                 "get_address": {
-                    "skills": [{"get_address": {"source": None}}]  # This will cause an attribute error when accessed
+                    "tools": [{"get_address": {"source": None}}]  # This will cause an attribute error when accessed
                 }
             }
         }
@@ -754,8 +755,8 @@ def test_load_default_test_definition_exception_handling(mocker):
         assert result is None
 
 
-def test_load_skill_folder_zip_creation_failure(mocker):
-    """Test load_skill_folder when create_skill_folder_zip returns None."""
+def test_load_tool_folder_zip_creation_failure(mocker):
+    """Test load_tool_folder when create_tool_folder_zip returns None."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
@@ -764,20 +765,20 @@ def test_load_skill_folder_zip_creation_failure(mocker):
         definition = {
             "agents": {
                 "get_address": {
-                    "skills": [{"get_address": {"name": "Get Address", "source": {"path": "skills/get_address"}}}]
+                    "tools": [{"get_address": {"name": "Get Address", "source": {"path": "tools/get_address"}}}]
                 }
             }
         }
 
-        # Mock create_skill_folder_zip to return None, simulating a failure
-        mocker.patch("weni_cli.commands.run.create_skill_folder_zip", return_value=(None, "Failed to create skill folder for skill get_address in agent get_address"))
+        # Mock create_tool_folder_zip to return None, simulating a failure
+        mocker.patch("weni_cli.commands.run.create_tool_folder_zip", return_value=(None, "Failed to create tool folder for tool get_address in agent get_address"))
 
         # Call the method directly and check the result
-        result, error = handler.load_skill_folder(definition, "get_address", "get_address")
+        result, error = handler.load_tool_folder(definition, "get_address", "get_address")
 
         # Verify the function returns None on failure
         assert result is None
-        assert "Failed to create skill folder for skill get_address in agent get_address" in str(error)
+        assert "Failed to create tool folder for tool get_address in agent get_address" in str(error)
 
 
 def test_render_response_and_logs(capsys):
@@ -807,24 +808,24 @@ def test_render_response_and_logs(capsys):
         assert "More log data" in captured.out
 
 
-def test_parse_agent_skill_with_empty_string():
-    """Test parse_agent_skill method with an empty string."""
+def test_parse_agent_tool_with_empty_string():
+    """Test parse_agent_tool method with an empty string."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        agent_key, skill_key = handler.parse_agent_skill("")
+        agent_key, tool_key = handler.parse_agent_tool("")
         assert agent_key is None
-        assert skill_key is None
+        assert tool_key is None
 
 
-def test_parse_agent_skill_without_delimiter():
-    """Test parse_agent_skill method with a string that doesn't contain a delimiter."""
+def test_parse_agent_tool_without_delimiter():
+    """Test parse_agent_tool method with a string that doesn't contain a delimiter."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
-        agent_key, skill_key = handler.parse_agent_skill("agentskill")
+        agent_key, tool_key = handler.parse_agent_tool("agenttool")
         assert agent_key is None
-        assert skill_key is None
+        assert tool_key is None
 
 
 def test_run_test_uses_new_methods(mocker):
@@ -877,8 +878,8 @@ def test_run_test_uses_new_methods(mocker):
         handler.run_test(
             "project_uuid",
             {"test": "definition"},
-            b"skill_folder",
-            "Skill Name",
+            b"tool_folder",
+            "Tool Name",
             "Agent Name",
             {"test": "test_definition"},
             {"API_KEY": "key"},
@@ -947,8 +948,8 @@ def test_run_test_verbose_triggers_render_logs(mocker):
         handler.run_test(
             "project_uuid",
             {"test": "definition"},
-            b"skill_folder",
-            "Skill Name",
+            b"tool_folder",
+            "Tool Name",
             "Agent Name",
             {"test": "test_definition"},
             {"API_KEY": "key"},
@@ -963,15 +964,15 @@ def test_run_test_verbose_triggers_render_logs(mocker):
         render_mock.assert_called_once_with(test_logs)
 
 
-def test_parse_agent_skill_with_out_of_bounds_index():
-    """Test parse_agent_skill method with an index error."""
+def test_parse_agent_tool_with_out_of_bounds_index():
+    """Test parse_agent_tool method with an index error."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         handler = RunHandler()
         # This generates an index error when trying to access [1]
-        agent_key, skill_key = handler.parse_agent_skill("agent")
+        agent_key, tool_key = handler.parse_agent_tool("agent")
         assert agent_key is None
-        assert skill_key is None
+        assert tool_key is None
 
 
 def test_display_test_results_comprehensive(mocker):
@@ -985,7 +986,7 @@ def test_display_test_results_comprehensive(mocker):
         mocker.patch("weni_cli.commands.run.Table", return_value=table_mock)
 
         # Test with empty rows
-        result = handler.display_test_results([], "Test Skill")
+        result = handler.display_test_results([], "Test Tool")
         assert result is None
 
         # Test with various rows
@@ -1001,7 +1002,7 @@ def test_display_test_results_comprehensive(mocker):
         )
 
         # Call the method
-        result = handler.display_test_results(rows, "Test Skill")
+        result = handler.display_test_results(rows, "Test Tool")
 
         # Verify table creation
         assert result == table_mock
@@ -1050,7 +1051,7 @@ def test_update_live_display_add_new_row(mocker):
             status_code=200,
             code="TEST_CASE_COMPLETED",
             live_display=live_mock,
-            skill_name="Test Skill",
+            tool_name="Test Tool",
         )
 
         # Verify the row was added to test_rows
@@ -1061,7 +1062,7 @@ def test_update_live_display_add_new_row(mocker):
         assert test_rows[0]["code"] == "TEST_CASE_COMPLETED"
 
         # Verify that the display method was called correctly
-        display_mock.assert_called_once_with(test_rows, "Test Skill", False)
+        display_mock.assert_called_once_with(test_rows, "Test Tool", False)
 
         # Verify that the live display was updated
         live_mock.update.assert_called_once_with("Test Table", refresh=True)
@@ -1090,7 +1091,7 @@ def test_update_live_display_update_existing_row(mocker):
             status_code=400,
             code="TEST_CASE_COMPLETED",
             live_display=live_mock,
-            skill_name="Test Skill",
+            tool_name="Test Tool",
         )
 
         # Verify the row was updated in test_rows
@@ -1101,7 +1102,7 @@ def test_update_live_display_update_existing_row(mocker):
         assert test_rows[0]["code"] == "TEST_CASE_COMPLETED"  # Updated code
 
         # Verify that the display method was called correctly
-        display_mock.assert_called_once_with(test_rows, "Test Skill", False)
+        display_mock.assert_called_once_with(test_rows, "Test Tool", False)
 
         # Verify that the live display was updated
         live_mock.update.assert_called_once_with("Test Table", refresh=True)
@@ -1116,9 +1117,9 @@ def test_execute_with_none_test_definition(mocker, mock_store_values):
         # Use the fixture to mock Store.get to return a project UUID
         mock_store_values(mocker, project_uuid="mock-project-uuid")
 
-        # Create a realistic definition with the expected agent and skill structure
+        # Create a realistic definition with the expected agent and tool structure
         definition_data = {
-            "agents": {"test_agent": {"skills": [{"test_skill": {"source": {"path": "skills/test_skill"}}}]}}
+            "agents": {"test_agent": {"tools": [{"test_tool": {"source": {"path": "tools/test_tool"}}}]}}
         }
 
         # Mock load_agent_definition to return our definition data the first time (for the agent definition)
@@ -1132,22 +1133,22 @@ def test_execute_with_none_test_definition(mocker, mock_store_values):
 
         # Mock format_definition to return a formatted definition with the same structure
         formatted_definition = {
-            "agents": {"test_agent": {"skills": [{"key": "test_skill", "source": {"path": "skills/test_skill"}}]}}
+            "agents": {"test_agent": {"tools": [{"key": "test_tool", "source": {"path": "tools/test_tool"}}]}}
         }
         mocker.patch("weni_cli.commands.run.format_definition", return_value=(formatted_definition, None))
 
-        # Mock load_skill_folder to return a mock skill folder
-        load_skill_folder_mock = mocker.patch.object(handler, "load_skill_folder")
-        load_skill_folder_mock.return_value = (b"mock_skill_folder_content", None)
+        # Mock load_tool_folder to return a mock tool folder
+        load_tool_folder_mock = mocker.patch.object(handler, "load_tool_folder")
+        load_tool_folder_mock.return_value = (b"mock_tool_folder_content", None)
 
         # Spy on methods that should not be called if we exit early
-        get_skill_source_path_spy = mocker.spy(handler, "get_skill_source_path")
+        get_tool_source_path_spy = mocker.spy(handler, "get_tool_source_path")
 
         # Call execute with arguments that will lead to loading test_definition
         result = handler.execute(
             definition="path/to/definition.json",
             agent_key="test_agent",
-            skill_key="test_skill",
+            tool_key="test_tool",
             test_definition="path/to/test_definition.json",
             verbose=False,
         )
@@ -1161,11 +1162,11 @@ def test_execute_with_none_test_definition(mocker, mock_store_values):
         assert mock_load_test_definition.call_count == 1
         assert mock_load_test_definition.call_args[0][0] == "path/to/test_definition.json"
 
-        # Verify that load_skill_folder was called
-        assert load_skill_folder_mock.called
+        # Verify that load_tool_folder was called
+        assert load_tool_folder_mock.called
 
-        # Verify that get_skill_source_path was NOT called since we should exit early
-        assert not get_skill_source_path_spy.called
+        # Verify that get_tool_source_path was NOT called since we should exit early
+        assert not get_tool_source_path_spy.called
 
 
 def test_run_command_unhandled_exception(mocker, create_mocked_files, mock_store_values):
@@ -1191,7 +1192,7 @@ def test_run_command_unhandled_exception(mocker, create_mocked_files, mock_store
         args, kwargs = mock_execute.call_args
         assert kwargs["definition"] == agent_file
         assert kwargs["agent_key"] == "get_address"
-        assert kwargs["skill_key"] == "get_address"
+        assert kwargs["tool_key"] == "get_address"
         assert kwargs["test_definition"] is None
         assert kwargs["verbose"] is False
 
@@ -1222,23 +1223,23 @@ def test_project_push_command_unhandled_exception(mocker):
         assert kwargs["force_update"] is False
 
 
-def test_run_command_invalid_format_definition(mocker, create_mocked_files, mock_store_values, mock_skill_folder):
+def test_run_command_invalid_format_definition(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
     """Test running a command when format_definition returns None."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         agent_file = create_mocked_files()
         _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_skill_folder(mocker)
+        mock_tool_folder(mocker)
 
         # Mock load_agent_definition to return valid data
         mocker.patch(
             "weni_cli.validators.definition.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "skills": []}}}, None),
+            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
         )
 
         # Patch the load_default_test_definition to return a valid file
         mocker.patch.object(
-            RunHandler, "load_default_test_definition", return_value="skills/get_address/test_definition.yaml"
+            RunHandler, "load_default_test_definition", return_value="tools/get_address/test_definition.yaml"
         )
 
         # Patch the format_definition to return None

--- a/weni_cli/cli.py
+++ b/weni_cli/cli.py
@@ -29,7 +29,7 @@ def login():
 # Init Command
 @cli.command("init")
 def init():
-    """Create a sample agent definition file and skills directory"""
+    """Create a sample agent definition file and tools directory"""
     from weni_cli.commands.init import InitHandler
 
     InitHandler().execute()
@@ -39,24 +39,24 @@ def init():
 @cli.command("run")
 @click.argument("definition", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.argument("agent_key", required=True, type=str)
-@click.argument("skill_key", required=True, type=str)
+@click.argument("tool_key", required=True, type=str)
 @click.option(
     "--file", "-f", help="The path to the test definition file", type=click.Path(exists=True, dir_okay=False)
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
-def run_test(definition, agent_key, skill_key, file, verbose):
-    """Run tests for a specific agent skill
+def run_test(definition, agent_key, tool_key, file, verbose):
+    """Run tests for a specific agent tool
 
     DEFINITION: The path to the YAML agent definition file
     AGENT_KEY: The agent key to be tested
-    SKILL_KEY: The skill key to be tested
+    TOOL_KEY: The tool key to be tested
     FILE: The path to the test definition file
     """
     from weni_cli.commands.run import RunHandler
 
     try:
         RunHandler().execute(
-            definition=definition, agent_key=agent_key, skill_key=skill_key, test_definition=file, verbose=verbose
+            definition=definition, agent_key=agent_key, tool_key=tool_key, test_definition=file, verbose=verbose
         )
     except Exception as e:
         click.echo(f"Error: {e}")

--- a/weni_cli/clients/cli_client.py
+++ b/weni_cli/clients/cli_client.py
@@ -152,14 +152,14 @@ class CLIClient:
         except RequestError as e:
             raise RequestError(f"Failed to check project permission: {e.message}")
 
-    def push_agents(self, project_uuid: str, agents_definition: Dict, skill_folders: Dict[str, BinaryIO]) -> None:
+    def push_agents(self, project_uuid: str, agents_definition: Dict, tool_folders: Dict[str, BinaryIO]) -> None:
         """Push agents to the API."""
         data = create_default_payload(project_uuid, agents_definition)
 
         with spinner():
             try:
                 with self._streaming_request(
-                    method="POST", endpoint="api/v1/agents", data=data, files=skill_folders
+                    method="POST", endpoint="api/v1/agents", data=data, files=tool_folders
                 ) as response:
                     self._handle_push_response(response)
             except RequestError as e:
@@ -191,22 +191,22 @@ class CLIClient:
         self,
         project_uuid: str,
         definition: Dict,
-        skill_folder: BinaryIO,
-        skill_name: str,
+        tool_folder: BinaryIO,
+        tool_name: str,
         agent_name: str,
         test_definition: Dict,
         credentials: Dict,
-        skill_globals: Dict,
+        tool_globals: Dict,
         result_callback: Callable[[str, Any, int, Optional[str], bool], None],
         verbose: bool = False,
     ) -> List[Dict]:
-        """Run a test for a skill."""
+        """Run a test for a tool."""
         test_logs = []
 
         data = self._prepare_test_data(
-            project_uuid, definition, test_definition, skill_name, agent_name, credentials, skill_globals
+            project_uuid, definition, test_definition, tool_name, agent_name, credentials, tool_globals
         )
-        files = {"skill": skill_folder}
+        files = {"tool": tool_folder}
 
         try:
             with self._streaming_request(method="POST", endpoint="api/v1/runs", data=data, files=files) as response:
@@ -221,20 +221,20 @@ class CLIClient:
         project_uuid: str,
         definition: Dict,
         test_definition: Dict,
-        skill_name: str,
+        tool_name: str,
         agent_name: str,
         credentials: Dict,
-        skill_globals: Dict,
+        tool_globals: Dict,
     ) -> Dict[str, str]:
         """Prepare data for the test run."""
         data = create_default_payload(project_uuid, definition)
         data.update(
             {
                 "test_definition": json.dumps(test_definition),
-                "skill_name": skill_name,
+                "tool_name": tool_name,
                 "agent_name": agent_name,
-                "skill_credentials": json.dumps(credentials),
-                "skill_globals": json.dumps(skill_globals),
+                "tool_credentials": json.dumps(credentials),
+                "tool_globals": json.dumps(tool_globals),
             }
         )
         return data

--- a/weni_cli/clients/tests/test_cli_client.py
+++ b/weni_cli/clients/tests/test_cli_client.py
@@ -246,10 +246,10 @@ def test_push_agents_success(client, requests_mock, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     agents_definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folders = {"test_skill": io.BytesIO(b"test skill content")}
+    tool_folders = {"test_tool": io.BytesIO(b"test tool content")}
 
     # Call the method
-    client.push_agents(project_uuid, agents_definition, skill_folders)
+    client.push_agents(project_uuid, agents_definition, tool_folders)
 
     # Verify progressbar was updated
     assert progress_instance.update.call_count == 2
@@ -278,11 +278,11 @@ def test_push_agents_error_response(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     agents_definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folders = {"test_skill": io.BytesIO(b"test skill content")}
+    tool_folders = {"test_tool": io.BytesIO(b"test tool content")}
 
     # Call the method and expect exception
     with pytest.raises(RequestError) as exc_info:
-        client.push_agents(project_uuid, agents_definition, skill_folders)
+        client.push_agents(project_uuid, agents_definition, tool_folders)
 
     # Verify the exception message
     assert "Error pushing agents" in str(exc_info.value)
@@ -310,11 +310,11 @@ def test_push_agents_error_no_message(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     agents_definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folders = {"test_skill": io.BytesIO(b"test skill content")}
+    tool_folders = {"test_tool": io.BytesIO(b"test tool content")}
 
     # Call the method and expect exception
     with pytest.raises(RequestError) as exc_info:
-        client.push_agents(project_uuid, agents_definition, skill_folders)
+        client.push_agents(project_uuid, agents_definition, tool_folders)
 
     # Verify the exception message
     assert "Unknown error during agent push" in str(exc_info.value)
@@ -335,11 +335,11 @@ def test_push_agents_http_error(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     agents_definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folders = {"test_skill": io.BytesIO(b"test skill content")}
+    tool_folders = {"test_tool": io.BytesIO(b"test tool content")}
 
     # Call the method and expect exception
     with pytest.raises(RequestError) as exc_info:
-        client.push_agents(project_uuid, agents_definition, skill_folders)
+        client.push_agents(project_uuid, agents_definition, tool_folders)
 
     # Verify the exception
     assert "500" in str(exc_info.value)
@@ -393,23 +393,23 @@ def test_run_test_success(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method
     test_logs = client.run_test(
         project_uuid,
         definition,
-        skill_folder,
-        skill_name,
+        tool_folder,
+        tool_name,
         agent_name,
         test_definition,
         credentials,
-        skill_globals,
+        tool_globals,
         result_callback,
         verbose=True,
     )
@@ -457,23 +457,23 @@ def test_run_test_non_verbose(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method with verbose=False
     test_logs = client.run_test(
         project_uuid,
         definition,
-        skill_folder,
-        skill_name,
+        tool_folder,
+        tool_name,
         agent_name,
         test_definition,
         credentials,
-        skill_globals,
+        tool_globals,
         result_callback,
         verbose=False,
     )
@@ -509,23 +509,23 @@ def test_run_test_error_message(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method
     test_logs = client.run_test(
         project_uuid,
         definition,
-        skill_folder,
-        skill_name,
+        tool_folder,
+        tool_name,
         agent_name,
         test_definition,
         credentials,
-        skill_globals,
+        tool_globals,
         result_callback,
         verbose=True,
     )
@@ -556,24 +556,24 @@ def test_run_test_http_error(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method and expect exception
     with pytest.raises(RequestError) as exc_info:
         client.run_test(
             project_uuid,
             definition,
-            skill_folder,
-            skill_name,
+            tool_folder,
+            tool_name,
             agent_name,
             test_definition,
             credentials,
-            skill_globals,
+            tool_globals,
             result_callback,
             verbose=True,
         )
@@ -602,23 +602,23 @@ def test_run_test_unknown_error(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method
     test_logs = client.run_test(
         project_uuid,
         definition,
-        skill_folder,
-        skill_name,
+        tool_folder,
+        tool_name,
         agent_name,
         test_definition,
         credentials,
-        skill_globals,
+        tool_globals,
         result_callback,
         verbose=True,
     )
@@ -649,23 +649,23 @@ def test_run_test_success_false_no_message(client, mocker):
     # Create test data
     project_uuid = "test-project-uuid"
     definition = {"agents": {"test_agent": {"name": "Test Agent"}}}
-    skill_folder = io.BytesIO(b"test skill content")
-    skill_name = "Test Skill"
+    tool_folder = io.BytesIO(b"test tool content")
+    tool_name = "Test Tool"
     agent_name = "Test Agent"
     test_definition = {"test_cases": [{"name": "Test 1", "input": "Test input"}]}
     credentials = {"API_KEY": "test-key"}
-    skill_globals = {"REGION": "us-east-1"}
+    tool_globals = {"REGION": "us-east-1"}
 
     # Call the method
     test_logs = client.run_test(
         project_uuid,
         definition,
-        skill_folder,
-        skill_name,
+        tool_folder,
+        tool_name,
         agent_name,
         test_definition,
         credentials,
-        skill_globals,
+        tool_globals,
         result_callback,
         verbose=True,
     )

--- a/weni_cli/commands/init.py
+++ b/weni_cli/commands/init.py
@@ -4,10 +4,10 @@ import os
 from weni_cli.commands.run import DEFAULT_TEST_DEFINITION_FILE
 from weni_cli.handler import Handler
 
-SKILLS_FOLDER = "skills"
+TOOLS_FOLDER = "tools"
 SAMPLE_AGENT_DEFINITION_FILE_NAME = "agent_definition.yaml"
 
-SAMPLE_GET_ADDRESS_SKILL_NAME = "get_address"
+SAMPLE_GET_ADDRESS_TOOL_NAME = "get_address"
 
 SAMPLE_AGENT_DEFINITION_YAML = f"""agents:
     cep_agent:
@@ -18,11 +18,11 @@ SAMPLE_AGENT_DEFINITION_YAML = f"""agents:
             - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
         guardrails:
             - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
-        skills:
+        tools:
             - get_address:
                 name: "Get Address"
                 source:
-                    path: "skills/get_address"
+                    path: "tools/get_address"
                     entrypoint: "main.GetAddress"
                     path_test: "{DEFAULT_TEST_DEFINITION_FILE}"
                 description: "Function to get the address from the postal code"
@@ -33,7 +33,7 @@ SAMPLE_AGENT_DEFINITION_YAML = f"""agents:
                         required: true
 """
 
-SAMPLE_GET_ADDRESS_SKILL_PY = """from weni import Skill
+SAMPLE_GET_ADDRESS_TOOL_PY = """from weni import Skill
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
@@ -70,12 +70,12 @@ SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT = """requests==2.32.3
 
 
 class InitHandler(Handler):
-    """Handles initialization of sample agent definition, skills, and tests."""
+    """Handles initialization of sample agent definition, tools, and tests."""
 
     def execute(self):
         """Execute the initialization process by creating sample files and folders."""
         self.create_sample_agent_definition_file()
-        self.create_sample_skills()
+        self.create_sample_tools()
         self.create_sample_tests()
 
     def create_sample_agent_definition_file(self):
@@ -86,52 +86,52 @@ class InitHandler(Handler):
             description="Sample agent definition file",
         )
 
-    def create_sample_skills(self):
-        """Create sample skills with their respective files."""
-        self.create_sample_skill(
-            skill_name=SAMPLE_GET_ADDRESS_SKILL_NAME,
-            code=SAMPLE_GET_ADDRESS_SKILL_PY,
+    def create_sample_tools(self):
+        """Create sample tools with their respective files."""
+        self.create_sample_tool(
+            tool_name=SAMPLE_GET_ADDRESS_TOOL_NAME,
+            code=SAMPLE_GET_ADDRESS_TOOL_PY,
             requirements=SAMPLE_GET_ADDRESS_REQUIREMENTS_TXT,
         )
 
-    def create_sample_skill(self, skill_name, code, requirements):
+    def create_sample_tool(self, tool_name, code, requirements):
         """
-        Create a sample skill with its main code file and requirements.
+        Create a sample tool with its main code file and requirements.
 
         Args:
-            skill_name: Name of the skill
-            code: Python code content for the skill
+            tool_name: Name of the tool
+            code: Python code content for the tool
             requirements: Requirements content for pip
         """
-        # Ensure the skills folder structure exists
-        self._ensure_directory(SKILLS_FOLDER)
-        self._ensure_directory(f"{SKILLS_FOLDER}/{skill_name}")
+        # Ensure the tools folder structure exists
+        self._ensure_directory(TOOLS_FOLDER)
+        self._ensure_directory(f"{TOOLS_FOLDER}/{tool_name}")
 
-        # Create the main skill file
-        skill_path = f"{SKILLS_FOLDER}/{skill_name}/main.py"
-        self._write_file(filename=skill_path, content=code, description=f"Sample skill {skill_name}")
+        # Create the main tool file
+        tool_path = f"{TOOLS_FOLDER}/{tool_name}/main.py"
+        self._write_file(filename=tool_path, content=code, description=f"Sample tool {tool_name}")
 
         # Create the requirements file
         self._write_file(
-            filename=f"{SKILLS_FOLDER}/{skill_name}/requirements.txt",
+            filename=f"{TOOLS_FOLDER}/{tool_name}/requirements.txt",
             content=requirements,
-            description=f"Sample requirements file for {skill_name}",
+            description=f"Sample requirements file for {tool_name}",
         )
 
     def create_sample_tests(self):
-        """Create sample test files for the skills."""
-        self.create_sample_test(skill_name=SAMPLE_GET_ADDRESS_SKILL_NAME, test_content=SAMPLE_TESTS_YAML)
+        """Create sample test files for the tools."""
+        self.create_sample_test(tool_name=SAMPLE_GET_ADDRESS_TOOL_NAME, test_content=SAMPLE_TESTS_YAML)
 
-    def create_sample_test(self, skill_name, test_content):
+    def create_sample_test(self, tool_name, test_content):
         """
-        Create a sample test file for a skill.
+        Create a sample test file for a tool.
 
         Args:
-            skill_name: Name of the skill to create tests for
+            tool_name: Name of the tool to create tests for
             test_content: YAML content for the test file
         """
-        test_path = f"{SKILLS_FOLDER}/{skill_name}/{DEFAULT_TEST_DEFINITION_FILE}"
-        self._write_file(filename=test_path, content=test_content, description=f"Sample tests file for {skill_name}")
+        test_path = f"{TOOLS_FOLDER}/{tool_name}/{DEFAULT_TEST_DEFINITION_FILE}"
+        self._write_file(filename=test_path, content=test_content, description=f"Sample tests file for {tool_name}")
 
     def _ensure_directory(self, directory_path):
         """

--- a/weni_cli/commands/init.py
+++ b/weni_cli/commands/init.py
@@ -33,13 +33,13 @@ SAMPLE_AGENT_DEFINITION_YAML = f"""agents:
                         required: true
 """
 
-SAMPLE_GET_ADDRESS_TOOL_PY = """from weni import Skill
+SAMPLE_GET_ADDRESS_TOOL_PY = """from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
 
-class GetAddress(Skill):
+class GetAddress(Tool):
     def execute(self, context: Context) -> TextResponse:
         cep = context.parameters.get("cep", "")
         print(cep)

--- a/weni_cli/commands/project_push.py
+++ b/weni_cli/commands/project_push.py
@@ -6,7 +6,7 @@ from slugify import slugify
 from weni_cli.formatter.formatter import Formatter
 from weni_cli.clients.cli_client import CLIClient
 from weni_cli.handler import Handler
-from weni_cli.packager.packager import create_skill_folder_zip
+from weni_cli.packager.packager import create_tool_folder_zip
 from weni_cli.store import STORE_PROJECT_UUID_KEY, Store
 from weni_cli.validators.definition import format_definition, load_agent_definition
 
@@ -32,13 +32,13 @@ class ProjectPushHandler(Handler):
             formatter.print_error_panel(f"Invalid agent definition YAML file format, error:\n{error}", title="Failed to load definition file")
             return
 
-        skills_folders_map, error = self.load_skills_folders(definition_data)
+        tools_folders_map, error = self.load_tools_folders(definition_data)
         if error:
             formatter.print_error_panel(error)
             return
 
         definition = format_definition(definition_data)
-        self.push_definition(force_update, project_uuid, definition, skills_folders_map)
+        self.push_definition(force_update, project_uuid, definition, tools_folders_map)
 
     def load_param(self, params, key, default=None, required=False):
         value = params.get(key, default)
@@ -46,28 +46,28 @@ class ProjectPushHandler(Handler):
             raise Exception(f"Missing required parameter {key}")
         return value
 
-    def load_skills_folders(self, definition) -> tuple[Optional[dict], Optional[str]]:
-        skills_folder_map = {}
+    def load_tools_folders(self, definition) -> tuple[Optional[dict], Optional[str]]:
+        tools_folder_map = {}
 
         agents = definition.get("agents", {})
 
         for _, agent_data in agents.items():
-            skills = agent_data.get("skills", {})
-            for skill in skills:
-                for _, skill_data in skill.items():
+            tools = agent_data.get("tools", {})
+            for tool in tools:
+                for _, tool_data in tool.items():
                     agent_name_slug = slugify(agent_data.get("name"))
-                    skill_slug = slugify(skill_data.get("name"))
-                    skill_folder, error = create_skill_folder_zip(skill_slug, skill_data.get("source").get("path"))
+                    tool_slug = slugify(tool_data.get("name"))
+                    tool_folder, error = create_tool_folder_zip(tool_slug, tool_data.get("source").get("path"))
                     if error:
-                        return None, f"Failed to create skill folder for skill {skill_data.get('name')} in agent {agent_data.get('name')}\n{error}"
+                        return None, f"Failed to create tool folder for tool {tool_data.get('name')} in agent {agent_data.get('name')}\n{error}"
 
-                    skills_folder_map[f"{agent_name_slug}:{skill_slug}"] = skill_folder
+                    tools_folder_map[f"{agent_name_slug}:{tool_slug}"] = tool_folder
 
-        return skills_folder_map, None
+        return tools_folder_map, None
 
-    def push_definition(self, force_update, project_uuid, definition, skill_folders_map):
+    def push_definition(self, force_update, project_uuid, definition, tool_folders_map):
         client = CLIClient()
 
-        client.push_agents(project_uuid, definition, skill_folders_map)
+        client.push_agents(project_uuid, definition, tool_folders_map)
 
         click.echo("Definition pushed successfully")

--- a/weni_cli/packager/packager.py
+++ b/weni_cli/packager/packager.py
@@ -5,12 +5,12 @@ from typing import Optional
 from zipfile import ZipFile
 
 
-def create_skill_folder_zip(skill_name, skill_path) -> tuple[Optional[BufferedReader], Optional[Exception]]:
-    zip_file_name = f"{skill_name}.zip"
-    zip_file_path = f"{skill_path}{os.sep}{zip_file_name}"
+def create_tool_folder_zip(tool_name, tool_path) -> tuple[Optional[BufferedReader], Optional[Exception]]:
+    zip_file_name = f"{tool_name}.zip"
+    zip_file_path = f"{tool_path}{os.sep}{zip_file_name}"
 
-    if not os.path.exists(skill_path):
-        return None, Exception(f"Folder {skill_path} not found")
+    if not os.path.exists(tool_path):
+        return None, Exception(f"Folder {tool_path} not found")
 
     # delete the existing zip file if it exists
     if os.path.exists(zip_file_path):
@@ -18,7 +18,7 @@ def create_skill_folder_zip(skill_name, skill_path) -> tuple[Optional[BufferedRe
 
     try:
         with ZipFile(zip_file_path, "w") as z:
-            for root, _, files in os.walk(skill_path):
+            for root, _, files in os.walk(tool_path):
                 # skip the newly created zip file to avoid adding it to itself
                 if zip_file_name in files:
                     files.remove(zip_file_name)
@@ -29,8 +29,8 @@ def create_skill_folder_zip(skill_name, skill_path) -> tuple[Optional[BufferedRe
 
                 # add the remaining files to the zip file
                 for file in files:
-                    z.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), skill_path))
+                    z.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), tool_path))
 
         return open(zip_file_path, "rb"), None
     except Exception as error:
-        return None, Exception(f"Failed to create skill zip file for skill path {skill_path}: {error}")
+        return None, Exception(f"Failed to create tool zip file for tool path {tool_path}: {error}")

--- a/weni_cli/packager/tests/test_packager.py
+++ b/weni_cli/packager/tests/test_packager.py
@@ -2,50 +2,50 @@ import os
 import pytest
 from zipfile import ZipFile
 from click.testing import CliRunner
-from weni_cli.packager.packager import create_skill_folder_zip
+from weni_cli.packager.packager import create_tool_folder_zip
 
 
 @pytest.fixture
-def skill_setup():
-    """Set up a temporary skill folder with test files."""
+def tool_setup():
+    """Set up a temporary tool folder with test files."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create the skill directory and files
-        skill_name = "test-skill"
-        skill_path = "skill_folder"
-        os.makedirs(skill_path, exist_ok=True)
+        # Create the tool directory and files
+        tool_name = "test-tool"
+        tool_path = "tool_folder"
+        os.makedirs(tool_path, exist_ok=True)
 
-        # Create main skill file
-        with open(f"{skill_path}/skill.py", "w") as f:
+        # Create main tool file
+        with open(f"{tool_path}/tool.py", "w") as f:
             f.write("def run(input, context):\n    return f'Processed: {input}'")
 
         # Create a requirements file
-        with open(f"{skill_path}/requirements.txt", "w") as f:
+        with open(f"{tool_path}/requirements.txt", "w") as f:
             f.write("requests==2.32.3\n")
 
         # Create a nested directory
-        os.makedirs(f"{skill_path}/utils", exist_ok=True)
-        with open(f"{skill_path}/utils/helpers.py", "w") as f:
+        os.makedirs(f"{tool_path}/utils", exist_ok=True)
+        with open(f"{tool_path}/utils/helpers.py", "w") as f:
             f.write("def format_response(text):\n    return text.upper()")
 
         # Create a __pycache__ directory that should be skipped
-        os.makedirs(f"{skill_path}/__pycache__", exist_ok=True)
-        with open(f"{skill_path}/__pycache__/cached.pyc", "w") as f:
+        os.makedirs(f"{tool_path}/__pycache__", exist_ok=True)
+        with open(f"{tool_path}/__pycache__/cached.pyc", "w") as f:
             f.write("# This should be skipped")
 
-        yield skill_name, skill_path
+        yield tool_name, tool_path
 
         # Clean up any zip files that might have been created
-        if os.path.exists(f"{skill_path}/{skill_name}.zip"):
-            os.remove(f"{skill_path}/{skill_name}.zip")
+        if os.path.exists(f"{tool_path}/{tool_name}.zip"):
+            os.remove(f"{tool_path}/{tool_name}.zip")
 
 
-def test_create_skill_folder_zip_success(skill_setup, mocker):
-    """Test successful creation of a skill folder zip."""
-    skill_name, skill_path = skill_setup
+def test_create_tool_folder_zip_success(tool_setup, mocker):
+    """Test successful creation of a tool folder zip."""
+    tool_name, tool_path = tool_setup
 
     # Call the function
-    result, error = create_skill_folder_zip(skill_name, skill_path)
+    result, error = create_tool_folder_zip(tool_name, tool_path)
 
     # Verify the result is a file-like object
     assert result is not None
@@ -58,7 +58,7 @@ def test_create_skill_folder_zip_success(skill_setup, mocker):
     result.close()
 
     # Verify the zip file was created
-    zip_path = f"{skill_path}/{skill_name}.zip"
+    zip_path = f"{tool_path}/{tool_name}.zip"
     assert os.path.exists(zip_path)
 
     # Verify the contents of the zip file
@@ -66,7 +66,7 @@ def test_create_skill_folder_zip_success(skill_setup, mocker):
         file_list = z.namelist()
 
         # Check expected files are included
-        assert "skill.py" in file_list
+        assert "tool.py" in file_list
         assert "requirements.txt" in file_list
         assert "utils/helpers.py" in file_list
 
@@ -75,10 +75,10 @@ def test_create_skill_folder_zip_success(skill_setup, mocker):
         assert "__pycache__/cached.pyc" not in file_list
 
 
-def test_create_skill_folder_zip_nonexistent_path(mocker):
-    """Test handling of non-existent skill path."""
+def test_create_tool_folder_zip_nonexistent_path(mocker):
+    """Test handling of non-existent tool path."""
     # Call with non-existent path
-    result, error = create_skill_folder_zip("test-skill", "nonexistent_path")
+    result, error = create_tool_folder_zip("test-tool", "nonexistent_path")
 
     # Verify the result is None
     assert result is None
@@ -88,10 +88,10 @@ def test_create_skill_folder_zip_nonexistent_path(mocker):
     assert "Folder nonexistent_path not found" in str(error)
 
 
-def test_create_skill_folder_zip_overwrites_existing(skill_setup):
+def test_create_tool_folder_zip_overwrites_existing(tool_setup):
     """Test that the function overwrites existing zip files."""
-    skill_name, skill_path = skill_setup
-    zip_path = f"{skill_path}/{skill_name}.zip"
+    tool_name, tool_path = tool_setup
+    zip_path = f"{tool_path}/{tool_name}.zip"
 
     # Create a dummy zip file
     with ZipFile(zip_path, "w") as z:
@@ -106,7 +106,7 @@ def test_create_skill_folder_zip_overwrites_existing(skill_setup):
     time.sleep(0.1)
 
     # Call the function which should overwrite the existing zip
-    result, error = create_skill_folder_zip(skill_name, skill_path)
+    result, error = create_tool_folder_zip(tool_name, tool_path)
     assert result is not None
     result.close()
 
@@ -120,38 +120,38 @@ def test_create_skill_folder_zip_overwrites_existing(skill_setup):
     with ZipFile(zip_path, "r") as z:
         file_list = z.namelist()
         assert "dummy.txt" not in file_list
-        assert "skill.py" in file_list
+        assert "tool.py" in file_list
 
 
-def test_create_skill_folder_zip_exception_handling(skill_setup, mocker):
+def test_create_tool_folder_zip_exception_handling(tool_setup, mocker):
     """Test handling of exceptions during zip creation."""
-    skill_name, skill_path = skill_setup
+    tool_name, tool_path = tool_setup
 
     # Mock ZipFile to raise an exception
     mock_zipfile = mocker.patch("weni_cli.packager.packager.ZipFile")
     mock_zipfile.side_effect = Exception("Simulated error")
 
     # Call the function
-    result, error = create_skill_folder_zip(skill_name, skill_path)
+    result, error = create_tool_folder_zip(tool_name, tool_path)
 
     # Verify the result is None due to the exception
     assert result is None
 
     # Verify the error is not None
     assert error is not None
-    assert "Failed to create skill zip file for skill path" in str(error)
+    assert "Failed to create tool zip file for tool path" in str(error)
     assert "Simulated error" in str(error)
 
 
-def test_create_skill_folder_zip_skips_zip_file(skill_setup, mocker):
+def test_create_tool_folder_zip_skips_zip_file(tool_setup, mocker):
     """Test that the zip file itself is not included in the zip."""
-    skill_name, skill_path = skill_setup
+    tool_name, tool_path = tool_setup
 
     # Create a spy on the ZipFile.write method to see what files are added
     spy_write = mocker.spy(ZipFile, "write")
 
     # Call the function
-    result, error = create_skill_folder_zip(skill_name, skill_path)
+    result, error = create_tool_folder_zip(tool_name, tool_path)
     assert result is not None
     result.close()
 
@@ -161,19 +161,19 @@ def test_create_skill_folder_zip_skips_zip_file(skill_setup, mocker):
     # Verify the zip file itself was not added to the zip
     for call_args in spy_write.call_args_list:
         filepath = call_args[0][1]  # The filepath argument
-        assert f"{skill_name}.zip" not in filepath
+        assert f"{tool_name}.zip" not in filepath
 
 
-def test_create_skill_folder_zip_with_empty_folder(mocker):
-    """Test creating a zip with an empty skill folder."""
+def test_create_tool_folder_zip_with_empty_folder(mocker):
+    """Test creating a zip with an empty tool folder."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create an empty skill directory
-        skill_path = "empty_skill"
-        os.makedirs(skill_path, exist_ok=True)
+        # Create an empty tool directory
+        tool_path = "empty_tool"
+        os.makedirs(tool_path, exist_ok=True)
 
         # Call the function
-        result, error = create_skill_folder_zip("empty-skill", skill_path)
+        result, error = create_tool_folder_zip("empty-tool", tool_path)
 
         # Verify the result is not None
         assert result is not None
@@ -183,19 +183,19 @@ def test_create_skill_folder_zip_with_empty_folder(mocker):
         assert error is None
 
         # Verify an empty zip was created
-        with ZipFile(f"{skill_path}/empty-skill.zip", "r") as z:
+        with ZipFile(f"{tool_path}/empty-tool.zip", "r") as z:
             assert len(z.namelist()) == 0
 
 
-def test_create_skill_folder_zip_with_relative_path(mocker):
+def test_create_tool_folder_zip_with_relative_path(mocker):
     """Test creating a zip with a relative path."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         # Create a nested directory structure
-        os.makedirs("project/skills/my_skill", exist_ok=True)
+        os.makedirs("project/tools/my_tool", exist_ok=True)
 
-        # Create a file in the skill directory
-        with open("project/skills/my_skill/skill.py", "w") as f:
+        # Create a file in the tool directory
+        with open("project/tools/my_tool/tool.py", "w") as f:
             f.write("def run(input, context):\n    return input")
 
         # Change to the project directory
@@ -204,7 +204,7 @@ def test_create_skill_folder_zip_with_relative_path(mocker):
 
         try:
             # Call the function with a relative path
-            result, error = create_skill_folder_zip("my-skill", "skills/my_skill")
+            result, error = create_tool_folder_zip("my-tool", "tools/my_tool")
 
             # Verify the result is not None
             assert result is not None
@@ -214,38 +214,38 @@ def test_create_skill_folder_zip_with_relative_path(mocker):
             assert error is None
 
             # Verify the zip file was created in the correct location
-            assert os.path.exists("skills/my_skill/my-skill.zip")
+            assert os.path.exists("tools/my_tool/my-tool.zip")
 
             # Verify the contents
-            with ZipFile("skills/my_skill/my-skill.zip", "r") as z:
-                assert "skill.py" in z.namelist()
+            with ZipFile("tools/my_tool/my-tool.zip", "r") as z:
+                assert "tool.py" in z.namelist()
         finally:
             # Change back to the original directory
             os.chdir(current_dir)
 
 
-def test_create_skill_folder_zip_with_nested_duplicate_filenames(mocker):
+def test_create_tool_folder_zip_with_nested_duplicate_filenames(mocker):
     """Test creating a zip with duplicate filenames in different directories."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create a skill directory with nested folders containing files with the same name
-        skill_path = "skill_with_dupes"
-        os.makedirs(f"{skill_path}/dir1", exist_ok=True)
-        os.makedirs(f"{skill_path}/dir2", exist_ok=True)
+        # Create a tool directory with nested folders containing files with the same name
+        tool_path = "tool_with_dupes"
+        os.makedirs(f"{tool_path}/dir1", exist_ok=True)
+        os.makedirs(f"{tool_path}/dir2", exist_ok=True)
 
         # Create files with the same name in different directories
-        with open(f"{skill_path}/dir1/config.py", "w") as f:
+        with open(f"{tool_path}/dir1/config.py", "w") as f:
             f.write("# Config for dir1")
 
-        with open(f"{skill_path}/dir2/config.py", "w") as f:
+        with open(f"{tool_path}/dir2/config.py", "w") as f:
             f.write("# Config for dir2")
 
         # Create a file at the root level
-        with open(f"{skill_path}/main.py", "w") as f:
+        with open(f"{tool_path}/main.py", "w") as f:
             f.write("# Main file")
 
         # Call the function
-        result, error = create_skill_folder_zip("skill-with-dupes", skill_path)
+        result, error = create_tool_folder_zip("tool-with-dupes", tool_path)
 
         # Verify the result is not None
         assert result is not None
@@ -255,7 +255,7 @@ def test_create_skill_folder_zip_with_nested_duplicate_filenames(mocker):
         assert error is None
 
         # Verify the zip contains all files with proper paths
-        with ZipFile(f"{skill_path}/skill-with-dupes.zip", "r") as z:
+        with ZipFile(f"{tool_path}/tool-with-dupes.zip", "r") as z:
             file_list = z.namelist()
             assert "main.py" in file_list
             assert "dir1/config.py" in file_list

--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -8,7 +8,7 @@ from slugify import slugify
 MIN_INSTRUCTION_LENGTH = 40
 MIN_GUARDRAIL_LENGTH = 40
 MAX_AGENT_NAME_LENGTH = 55
-MAX_SKILL_NAME_LENGTH = 40
+MAX_TOOL_NAME_LENGTH = 40
 AVAILABLE_COMPONENTS = [
     "cta_message",
     "quick_replies",
@@ -103,102 +103,102 @@ def validate_agent_definition_schema(data):
                     if not isinstance(component["instructions"], str):
                         return f"Agent '{agent_key}': component at index {idx} must have a 'instructions' field with a string value in the agent definition file"
 
-        # Validate skills
-        if not agent_data.get("skills"):
-            return f"Agent '{agent_key}' is missing required field 'skills' in the agent definition file"
+        # Validate tools
+        if not agent_data.get("tools"):
+            return f"Agent '{agent_key}' is missing required field 'tools' in the agent definition file"
 
-        if not isinstance(agent_data["skills"], list):
-            return f"Agent '{agent_key}': 'skills' must be an array in the agent definition file"
+        if not isinstance(agent_data["tools"], list):
+            return f"Agent '{agent_key}': 'tools' must be an array in the agent definition file"
 
-        # Validate each skill
-        for skill_idx, skill_obj in enumerate(agent_data["skills"]):
-            if not isinstance(skill_obj, dict):
+        # Validate each tool
+        for tool_idx, tool_obj in enumerate(agent_data["tools"]):
+            if not isinstance(tool_obj, dict):
                 return (
-                    f"Agent '{agent_key}': skill at index {skill_idx} must be an object in the agent definition file"
+                    f"Agent '{agent_key}': tool at index {tool_idx} must be an object in the agent definition file"
                 )
 
-            # Each skill object should have one key that is the skill name
-            if len(skill_obj) != 1:
-                return f"Agent '{agent_key}': skill at index {skill_idx} must have exactly one key in the agent definition file"
+            # Each tool object should have one key that is the tool name
+            if len(tool_obj) != 1:
+                return f"Agent '{agent_key}': tool at index {tool_idx} must have exactly one key in the agent definition file"
 
-            skill_name = list(skill_obj.keys())[0]
-            skill_data = skill_obj[skill_name]
+            tool_name = list(tool_obj.keys())[0]
+            tool_data = tool_obj[tool_name]
 
-            if not isinstance(skill_data, dict):
-                return f"Agent '{agent_key}': skill '{skill_name}' data must be an object in the agent definition file"
+            if not isinstance(tool_data, dict):
+                return f"Agent '{agent_key}': tool '{tool_name}' data must be an object in the agent definition file"
 
-            # Check required skill fields
+            # Check required tool fields
             # Validate name (required, must be string)
-            if not skill_data.get("name"):
-                return f"Agent '{agent_key}': skill '{skill_name}' is missing required field 'name' in the agent definition file"
-            if not isinstance(skill_data["name"], str):
+            if not tool_data.get("name"):
+                return f"Agent '{agent_key}': tool '{tool_name}' is missing required field 'name' in the agent definition file"
+            if not isinstance(tool_data["name"], str):
                 return (
-                    f"Agent '{agent_key}': skill '{skill_name}': 'name' must be a string in the agent definition file"
+                    f"Agent '{agent_key}': tool '{tool_name}': 'name' must be a string in the agent definition file"
                 )
-            if len(skill_data["name"]) > MAX_SKILL_NAME_LENGTH:
-                return f"Agent '{agent_key}': skill '{skill_name}': 'name' must be less than {MAX_SKILL_NAME_LENGTH} characters in the agent definition file"
+            if len(tool_data["name"]) > MAX_TOOL_NAME_LENGTH:
+                return f"Agent '{agent_key}': tool '{tool_name}': 'name' must be less than {MAX_TOOL_NAME_LENGTH} characters in the agent definition file"
 
             # Validate description (required, must be string)
-            if not skill_data.get("description"):
-                return f"Agent '{agent_key}': skill '{skill_name}' is missing required field 'description' in the agent definition file"
-            if not isinstance(skill_data["description"], str):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'description' must be a string in the agent definition file"
+            if not tool_data.get("description"):
+                return f"Agent '{agent_key}': tool '{tool_name}' is missing required field 'description' in the agent definition file"
+            if not isinstance(tool_data["description"], str):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'description' must be a string in the agent definition file"
 
             # Validate source
-            if skill_data.get("source") is None:
-                return f"Agent '{agent_key}': skill '{skill_name}' is missing required field 'source' in the agent definition file"
+            if tool_data.get("source") is None:
+                return f"Agent '{agent_key}': tool '{tool_name}' is missing required field 'source' in the agent definition file"
 
-            if not isinstance(skill_data["source"], dict):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source' must be an object in the agent definition file"
+            if not isinstance(tool_data["source"], dict):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source' must be an object in the agent definition file"
 
             # Validate source path (required, must be string)
-            if not skill_data["source"].get("path"):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source' is missing required field 'path' in the agent definition file"
-            if not isinstance(skill_data["source"]["path"], str):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source.path' must be a string in the agent definition file"
+            if not tool_data["source"].get("path"):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source' is missing required field 'path' in the agent definition file"
+            if not isinstance(tool_data["source"]["path"], str):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source.path' must be a string in the agent definition file"
 
             # Validate source entrypoint (required, must be string)
-            if not skill_data["source"].get("entrypoint"):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source' is missing required field 'entrypoint' in the agent definition file"
-            if not isinstance(skill_data["source"]["entrypoint"], str):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source.entrypoint' must be a string in the agent definition file"
+            if not tool_data["source"].get("entrypoint"):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source' is missing required field 'entrypoint' in the agent definition file"
+            if not isinstance(tool_data["source"]["entrypoint"], str):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source.entrypoint' must be a string in the agent definition file"
 
             # Validate source path_test if present (must be string)
-            if "path_test" in skill_data["source"] and not isinstance(skill_data["source"]["path_test"], str):
-                return f"Agent '{agent_key}': skill '{skill_name}': 'source.path_test' must be a string in the agent definition file"
+            if "path_test" in tool_data["source"] and not isinstance(tool_data["source"]["path_test"], str):
+                return f"Agent '{agent_key}': tool '{tool_name}': 'source.path_test' must be a string in the agent definition file"
 
             # Validate parameters if present
-            if "parameters" in skill_data:
-                if not isinstance(skill_data["parameters"], list):
-                    return f"Agent '{agent_key}': skill '{skill_name}': 'parameters' must be an array in the agent definition file"
+            if "parameters" in tool_data:
+                if not isinstance(tool_data["parameters"], list):
+                    return f"Agent '{agent_key}': tool '{tool_name}': 'parameters' must be an array in the agent definition file"
 
                 # Validate each parameter
-                for param_idx, param_obj in enumerate(skill_data["parameters"]):
+                for param_idx, param_obj in enumerate(tool_data["parameters"]):
                     if not isinstance(param_obj, dict):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter at index {param_idx} must be an object in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter at index {param_idx} must be an object in the agent definition file"
 
                     # Each parameter object should have one key that is the parameter name
                     if len(param_obj) != 1:
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter at index {param_idx} must have exactly one key in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter at index {param_idx} must have exactly one key in the agent definition file"
 
                     param_name = list(param_obj.keys())[0]
                     param_data = param_obj[param_name]
 
                     if not isinstance(param_data, dict):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' data must be an object in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' data must be an object in the agent definition file"
 
                     # Check required parameter fields
                     # Validate description (required, must be string)
                     if not param_data.get("description"):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' is missing required field 'description' in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' is missing required field 'description' in the agent definition file"
                     if not isinstance(param_data["description"], str):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' description must be a string in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' description must be a string in the agent definition file"
 
                     # Validate type (required, must be string)
                     if not param_data.get("type"):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' is missing required field 'type' in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' is missing required field 'type' in the agent definition file"
                     if not isinstance(param_data["type"], str):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' type must be a string in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' type must be a string in the agent definition file"
 
                     # Check allowed types
                     if param_data["type"] not in [
@@ -208,26 +208,26 @@ def validate_agent_definition_schema(data):
                         "boolean",
                         "array",
                     ]:
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' type must be one of: string, number, integer, boolean, array in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' type must be one of: string, number, integer, boolean, array in the agent definition file"
 
                     # Validate required if present (must be boolean)
                     if "required" in param_data and not isinstance(param_data["required"], bool):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' required field must be a boolean in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' required field must be a boolean in the agent definition file"
 
                     # Validate contact_field if present (must be boolean)
                     if "contact_field" in param_data and not isinstance(param_data["contact_field"], bool):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' contact_field must be a boolean in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' contact_field must be a boolean in the agent definition file"
 
                     # If contact_field is True, validate parameter name
 
                     if param_data.get("contact_field") and not ContactFieldValidator.has_valid_contact_field_name(param_name):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must match the regex of a valid contact field: {re.escape(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX)} in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' name must match the regex of a valid contact field: {re.escape(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX)} in the agent definition file"
 
                     if param_data.get("contact_field") and not ContactFieldValidator.has_valid_contact_field_length(param_name):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must be {ContactFieldValidator.CONTACT_FIELD_MAX_LENGTH} characters or less in the agent definition file"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' name must be {ContactFieldValidator.CONTACT_FIELD_MAX_LENGTH} characters or less in the agent definition file"
 
                     if param_data.get("contact_field") and not ContactFieldValidator.has_allowed_parameter_name(param_name):
-                        return f"Agent '{agent_key}': skill '{skill_name}': parameter '{param_name}' name must not be a reserved contact field name in the agent definition file\nRestricted contact field names: {ContactFieldValidator.RESERVED_CONTACT_FIELDS}"
+                        return f"Agent '{agent_key}': tool '{tool_name}': parameter '{param_name}' name must not be a reserved contact field name in the agent definition file\nRestricted contact field names: {ContactFieldValidator.RESERVED_CONTACT_FIELDS}"
 
     return None
 
@@ -264,28 +264,28 @@ def load_test_definition(path) -> tuple[Any, Optional[Exception]]:
     return data, None
 
 
-# Updates the skills in the definition to be an array of objects containing name, path and slug
+# Updates the tools in the definition to be an array of objects containing name, path and slug
 def format_definition(definition: dict) -> Optional[dict]:
     agents = definition.get("agents", {})
 
     for agent in agents:
-        skills = agents[agent].get("skills", {})
-        agent_skills = []
-        for skill in skills:
-            for skill_name, skill_data in skill.items():
-                skill_slug = slugify(skill_data.get("name"))
-                agent_skills.append(
+        tools = agents[agent].get("tools", {})
+        agent_tools = []
+        for tool in tools:
+            for tool_name, tool_data in tool.items():
+                tool_slug = slugify(tool_data.get("name"))
+                agent_tools.append(
                     {
-                        "key": skill_name,
-                        "slug": skill_slug,
-                        "name": skill_data.get("name"),
-                        "source": skill_data.get("source"),
-                        "description": skill_data.get("description"),
-                        "parameters": skill_data.get("parameters"),
+                        "key": tool_name,
+                        "slug": tool_slug,
+                        "name": tool_data.get("name"),
+                        "source": tool_data.get("source"),
+                        "description": tool_data.get("description"),
+                        "parameters": tool_data.get("parameters"),
                     }
                 )
 
-        agents[agent]["skills"] = agent_skills
+        agents[agent]["tools"] = agent_tools
         agents[agent]["slug"] = slugify(agents[agent].get("name"))
 
     return definition

--- a/weni_cli/validators/tests/test_definition.py
+++ b/weni_cli/validators/tests/test_definition.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from weni_cli.validators.definition import (
     AVAILABLE_COMPONENTS,
     MAX_AGENT_NAME_LENGTH,
-    MAX_SKILL_NAME_LENGTH,
+    MAX_TOOL_NAME_LENGTH,
     load_yaml_file,
     load_agent_definition,
     format_definition,
@@ -39,13 +39,13 @@ agents:
   test_agent:
     name: Test Agent
     description: Test Description
-    skills:
-      - test_skill:
-          name: Test Skill
-          description: A test skill
+    tools:
+      - test_tool:
+          name: Test Tool
+          description: A test tool
           source:
-            path: skills/test_skill
-            entrypoint: main.TestSkill
+            path: tools/test_tool
+            entrypoint: main.TestTool
           parameters:
             - test_param:
                 type: string
@@ -68,9 +68,9 @@ agents:
 agents:
   test_agent
     name: Test Agent
-    skills:
-      - test_skill:
-          name: Test Skill
+    tools:
+      - test_tool:
+          name: Test Tool
             """
             )
 
@@ -92,12 +92,12 @@ def valid_definition():
         "agents": {
             "test_agent": {
                 "name": "Test Agent",
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "A test skill",
-                            "source": {"path": "skills/test_skill"},
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "A test tool",
+                            "source": {"path": "tools/test_tool"},
                             "parameters": [
                                 {"test_param": {"type": "string", "description": "Test parameter", "required": True}},
                                 {"optional_param": {"type": "number", "description": "Optional parameter"}},
@@ -124,7 +124,7 @@ def test_load_yaml_file_valid(sample_definition_file):
     assert "agents" in data
     assert "test_agent" in data["agents"]
     assert data["agents"]["test_agent"]["name"] == "Test Agent"
-    assert isinstance(data["agents"]["test_agent"]["skills"], list)
+    assert isinstance(data["agents"]["test_agent"]["tools"], list)
 
 
 def test_load_yaml_file_invalid(sample_definition_file):
@@ -173,24 +173,24 @@ def test_format_definition_valid(valid_definition):
     # Check that the slug was added
     assert result["agents"]["test_agent"]["slug"] == "test-agent"
 
-    # Check that skills were reformatted
-    skills = result["agents"]["test_agent"]["skills"]
-    assert isinstance(skills, list)
-    assert "key" in skills[0]
-    assert "slug" in skills[0]
-    assert "name" in skills[0]
-    assert skills[0]["key"] == "test_skill"
-    assert skills[0]["slug"] == "test-skill"
-    assert skills[0]["name"] == "Test Skill"
+    # Check that tools were reformatted
+    tools = result["agents"]["test_agent"]["tools"]
+    assert isinstance(tools, list)
+    assert "key" in tools[0]
+    assert "slug" in tools[0]
+    assert "name" in tools[0]
+    assert tools[0]["key"] == "test_tool"
+    assert tools[0]["slug"] == "test-tool"
+    assert tools[0]["name"] == "Test Tool"
 
 
-def test_format_definition_no_skills():
-    """Test formatting a definition with no skills."""
+def test_format_definition_no_tools():
+    """Test formatting a definition with no tools."""
     definition = {
         "agents": {
             "test_agent": {
                 "name": "Test Agent"
-                # No skills
+                # No tools
             }
         }
     }
@@ -207,10 +207,10 @@ def test_format_definition_no_skills():
     # Check that the slug was added
     assert result["agents"]["test_agent"]["slug"] == "test-agent"
 
-    # Check that skills is an empty list
-    skills = result["agents"]["test_agent"]["skills"]
-    assert isinstance(skills, list)
-    assert len(skills) == 0
+    # Check that tools is an empty list
+    tools = result["agents"]["test_agent"]["tools"]
+    assert isinstance(tools, list)
+    assert len(tools) == 0
 
 
 def test_is_valid_contact_field_name_valid():
@@ -253,7 +253,7 @@ def test_validate_agent_definition_calls_validate_schema(mocker, tmpdir):
         name: Test Agent
         description: Test description
         instructions: [Instruction 1]
-        skills: []
+        tools: []
     """
     )
 
@@ -353,14 +353,14 @@ def test_validate_definition_without_instructions():
                 "name": "Test Agent",
                 "description": "Test description",
                 # No instructions key
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "Test tool description",
                             "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
+                                "path": "tools/test",
+                                "entrypoint": "main.TestTool",
                             },
                         }
                     }
@@ -382,14 +382,14 @@ def test_validate_definition_without_guardrails():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 # No guardrails key
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "Test tool description",
                             "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
+                                "path": "tools/test",
+                                "entrypoint": "main.TestTool",
                             },
                         }
                     }
@@ -410,14 +410,14 @@ def test_validate_definition_with_invalid_instructions():
                 "name": "Test Agent",
                 "description": "Test description",
                 "instructions": "Not an array",  # String instead of array
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "Test tool description",
                             "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
+                                "path": "tools/test",
+                                "entrypoint": "main.TestTool",
                             },
                         }
                     }
@@ -439,14 +439,14 @@ def test_validate_definition_file_with_short_instruction():
                 "name": "Test Agent",
                 "description": "Test description",
                 "instructions": ["Short instruction"],
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "Test tool description",
                             "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
+                                "path": "tools/test",
+                                "entrypoint": "main.TestTool",
                             },
                         }
                     }
@@ -469,14 +469,14 @@ def test_validate_definition_with_invalid_guardrails():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": "Not an array",  # String instead of array
-                "skills": [
+                "tools": [
                     {
-                        "test_skill": {
-                            "name": "Test Skill",
-                            "description": "Test skill description",
+                        "test_tool": {
+                            "name": "Test Tool",
+                            "description": "Test tool description",
                             "source": {
-                                "path": "skills/test",
-                                "entrypoint": "main.TestSkill",
+                                "path": "tools/test",
+                                "entrypoint": "main.TestTool",
                             },
                         }
                     }
@@ -622,8 +622,8 @@ def test_validate_agent_definition_with_short_guardrail():
     assert "Agent 'test_agent': guardrail at index 0 must have at least 40 characters in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skills():
-    """Test validation fails when skills are missing."""
+def test_validate_definition_with_missing_tools():
+    """Test validation fails when tools are missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -631,18 +631,18 @@ def test_validate_definition_with_missing_skills():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                # No skills key
+                # No tools key
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent' is missing required field 'skills' in the agent definition file" in error
+    assert "Agent 'test_agent' is missing required field 'tools' in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skills_type():
-    """Test validation fails when skills is not an array."""
+def test_validate_definition_with_invalid_tools_type():
+    """Test validation fails when tools is not an array."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -650,18 +650,18 @@ def test_validate_definition_with_invalid_skills_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": "Not an array",
+                "tools": "Not an array",
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': 'skills' must be an array in the agent definition file" in error
+    assert "Agent 'test_agent': 'tools' must be an array in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_type():
-    """Test validation fails when skill is not an object."""
+def test_validate_definition_with_invalid_tool_type():
+    """Test validation fails when tool is not an object."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -669,18 +669,18 @@ def test_validate_definition_with_invalid_skill_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [1, False, None],
+                "tools": [1, False, None],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill at index 0 must be an object in the agent definition file" in error
+    assert "Agent 'test_agent': tool at index 0 must be an object in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_format():
-    """Test validation fails when skill data is not a dictionary."""
+def test_validate_definition_with_invalid_tool_format():
+    """Test validation fails when tool data is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -688,9 +688,9 @@ def test_validate_definition_with_invalid_skill_format():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_name": "Skill 1",
+                        "tool_name": "Tool 1",
                         "data": "Not a dictionary",
                     }
                 ],
@@ -700,11 +700,11 @@ def test_validate_definition_with_invalid_skill_format():
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill at index 0 must have exactly one key in the agent definition file" in error
+    assert "Agent 'test_agent': tool at index 0 must have exactly one key in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_data_type():
-    """Test validation fails when skill data is not a dictionary."""
+def test_validate_definition_with_invalid_tool_data_type():
+    """Test validation fails when tool data is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -712,18 +712,18 @@ def test_validate_definition_with_invalid_skill_data_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": "Not a dictionary"}],
+                "tools": [{"tool_1": "Not a dictionary"}],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1' data must be an object in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1' data must be an object in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skill_name():
-    """Test validation fails when skill name is missing."""
+def test_validate_definition_with_missing_tool_name():
+    """Test validation fails when tool name is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -731,18 +731,18 @@ def test_validate_definition_with_missing_skill_name():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {}}],
+                "tools": [{"tool_1": {}}],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1' is missing required field 'name' in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1' is missing required field 'name' in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_name():
-    """Test validation fails when skill name is not a string."""
+def test_validate_definition_with_invalid_tool_name():
+    """Test validation fails when tool name is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -750,18 +750,18 @@ def test_validate_definition_with_invalid_skill_name():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": 123}}],
+                "tools": [{"tool_1": {"name": 123}}],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1': 'name' must be a string in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1': 'name' must be a string in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_name_length():
-    """Test validation fails when skill name is longer than the maximum allowed length."""
+def test_validate_definition_with_invalid_tool_name_length():
+    """Test validation fails when tool name is longer than the maximum allowed length."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -769,18 +769,18 @@ def test_validate_definition_with_invalid_skill_name_length():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": "kill Name with a really really really really really really really really really really really really long name"}}],
+                "tools": [{"tool_1": {"name": "Tool Name with a really really really really really really really really really really really really long name"}}],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert f"Agent 'test_agent': skill 'skill_1': 'name' must be less than {MAX_SKILL_NAME_LENGTH} characters in the agent definition file" in error
+    assert f"Agent 'test_agent': tool 'tool_1': 'name' must be less than {MAX_TOOL_NAME_LENGTH} characters in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skill_description():
-    """Test validation fails when skill description is missing."""
+def test_validate_definition_with_missing_tool_description():
+    """Test validation fails when tool description is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -788,7 +788,7 @@ def test_validate_definition_with_missing_skill_description():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": "Skill 1"}}],
+                "tools": [{"tool_1": {"name": "Tool 1"}}],
             }
         }
     }
@@ -796,13 +796,13 @@ def test_validate_definition_with_missing_skill_description():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1' is missing required field 'description' in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1' is missing required field 'description' in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_description():
-    """Test validation fails when skill description is not a string."""
+def test_validate_definition_with_invalid_tool_description():
+    """Test validation fails when tool description is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -810,18 +810,18 @@ def test_validate_definition_with_invalid_skill_description():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": "Skill 1", "description": 123}}],
+                "tools": [{"tool_1": {"name": "Tool 1", "description": 123}}],
             }
         }
     }
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1': 'description' must be a string in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1': 'description' must be a string in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skill_source():
-    """Test validation fails when skill source is missing."""
+def test_validate_definition_with_missing_tool_source():
+    """Test validation fails when tool source is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -829,7 +829,7 @@ def test_validate_definition_with_missing_skill_source():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": "Skill 1", "description": "Skill description"}}],
+                "tools": [{"tool_1": {"name": "Tool 1", "description": "Tool description"}}],
             }
         }
     }
@@ -837,12 +837,12 @@ def test_validate_definition_with_missing_skill_source():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1' is missing required field 'source' in the agent definition file" in error
+        "Agent 'test_agent': tool 'tool_1' is missing required field 'source' in the agent definition file" in error
     )
 
 
-def test_validate_definition_with_invalid_skill_source():
-    """Test validation fails when skill source is not a dictionary."""
+def test_validate_definition_with_invalid_tool_source():
+    """Test validation fails when tool source is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -850,8 +850,8 @@ def test_validate_definition_with_invalid_skill_source():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
-                    {"skill_1": {"name": "Skill 1", "description": "Skill description", "source": "Not a dictionary"}}
+                "tools": [
+                    {"tool_1": {"name": "Tool 1", "description": "Tool description", "source": "Not a dictionary"}}
                 ],
             }
         }
@@ -859,11 +859,11 @@ def test_validate_definition_with_invalid_skill_source():
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1': 'source' must be an object in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1': 'source' must be an object in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skill_source_path():
-    """Test validation fails when skill source path is missing."""
+def test_validate_definition_with_missing_tool_source_path():
+    """Test validation fails when tool source path is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -871,7 +871,7 @@ def test_validate_definition_with_missing_skill_source_path():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [{"skill_1": {"name": "Skill 1", "description": "Skill description", "source": {}}}],
+                "tools": [{"tool_1": {"name": "Tool 1", "description": "Tool description", "source": {}}}],
             }
         }
     }
@@ -879,13 +879,13 @@ def test_validate_definition_with_missing_skill_source_path():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': 'source' is missing required field 'path' in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': 'source' is missing required field 'path' in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_source_path():
-    """Test validation fails when skill source path is not a string."""
+def test_validate_definition_with_invalid_tool_source_path():
+    """Test validation fails when tool source path is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -893,8 +893,8 @@ def test_validate_definition_with_invalid_skill_source_path():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
-                    {"skill_1": {"name": "Skill 1", "description": "Skill description", "source": {"path": 123}}}
+                "tools": [
+                    {"tool_1": {"name": "Tool 1", "description": "Tool description", "source": {"path": 123}}}
                 ],
             }
         }
@@ -902,11 +902,11 @@ def test_validate_definition_with_invalid_skill_source_path():
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1': 'source.path' must be a string in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1': 'source.path' must be a string in the agent definition file" in error
 
 
-def test_validate_definition_with_missing_skill_source_entrypoint():
-    """Test validation fails when skill source entrypoint is missing."""
+def test_validate_definition_with_missing_tool_source_entrypoint():
+    """Test validation fails when tool source entrypoint is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -914,12 +914,12 @@ def test_validate_definition_with_missing_skill_source_entrypoint():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
-                            "source": {"path": "path/to/skill"},
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
+                            "source": {"path": "path/to/tool"},
                         }
                     }
                 ],
@@ -930,13 +930,13 @@ def test_validate_definition_with_missing_skill_source_entrypoint():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': 'source' is missing required field 'entrypoint' in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': 'source' is missing required field 'entrypoint' in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_source_entrypoint():
-    """Test validation fails when skill source entrypoint is not a string."""
+def test_validate_definition_with_invalid_tool_source_entrypoint():
+    """Test validation fails when tool source entrypoint is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -944,12 +944,12 @@ def test_validate_definition_with_invalid_skill_source_entrypoint():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
-                            "source": {"path": "path/to/skill", "entrypoint": 123},
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
+                            "source": {"path": "path/to/tool", "entrypoint": 123},
                         }
                     }
                 ],
@@ -960,13 +960,13 @@ def test_validate_definition_with_invalid_skill_source_entrypoint():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': 'source.entrypoint' must be a string in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': 'source.entrypoint' must be a string in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_source_path_test():
-    """Test validation fails when skill source path_test is not a string."""
+def test_validate_definition_with_invalid_tool_source_path_test():
+    """Test validation fails when tool source path_test is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -974,12 +974,12 @@ def test_validate_definition_with_invalid_skill_source_path_test():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
-                            "source": {"path": "path/to/skill", "entrypoint": "entrypoint", "path_test": 123},
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
+                            "source": {"path": "path/to/tool", "entrypoint": "entrypoint", "path_test": 123},
                         }
                     }
                 ],
@@ -990,13 +990,13 @@ def test_validate_definition_with_invalid_skill_source_path_test():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': 'source.path_test' must be a string in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': 'source.path_test' must be a string in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_type():
-    """Test validation fails when skill parameters is not a list."""
+def test_validate_definition_with_invalid_tool_parameters_type():
+    """Test validation fails when tool parameters is not a list."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1004,13 +1004,13 @@ def test_validate_definition_with_invalid_skill_parameters_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1024,11 +1024,11 @@ def test_validate_definition_with_invalid_skill_parameters_type():
 
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
-    assert "Agent 'test_agent': skill 'skill_1': 'parameters' must be an array in the agent definition file" in error
+    assert "Agent 'test_agent': tool 'tool_1': 'parameters' must be an array in the agent definition file" in error
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_format():
-    """Test validation fails when skill parameters item is not a dictionary."""
+def test_validate_definition_with_invalid_tool_parameters_item_format():
+    """Test validation fails when tool parameters item is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1036,13 +1036,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_format():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1057,13 +1057,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_format():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter at index 0 must be an object in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter at index 0 must be an object in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_format_dict_keys():
-    """Test validation fails when skill parameters item is not a dictionary."""
+def test_validate_definition_with_invalid_tool_parameters_item_format_dict_keys():
+    """Test validation fails when tool parameters item is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1071,13 +1071,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_format_dict_keys
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1092,13 +1092,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_format_dict_keys
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter at index 0 must have exactly one key in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter at index 0 must have exactly one key in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_type():
-    """Test validation fails when skill parameters item is not a dictionary."""
+def test_validate_definition_with_invalid_tool_parameters_item_type():
+    """Test validation fails when tool parameters item is not a dictionary."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1106,13 +1106,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1127,13 +1127,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' data must be an object in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' data must be an object in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_description_missing():
-    """Test validation fails when skill parameters item description is not a string."""
+def test_validate_definition_with_invalid_tool_parameters_item_description_missing():
+    """Test validation fails when tool parameters item description is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1141,13 +1141,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_description_miss
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1162,13 +1162,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_description_miss
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' is missing required field 'description' in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' is missing required field 'description' in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_description_not_string():
-    """Test validation fails when skill parameters item description is not a string."""
+def test_validate_definition_with_invalid_tool_parameters_item_description_not_string():
+    """Test validation fails when tool parameters item description is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1176,13 +1176,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_description_not_
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1197,13 +1197,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_description_not_
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' description must be a string in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' description must be a string in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_type_missing():
-    """Test validation fails when skill parameters item type is missing."""
+def test_validate_definition_with_invalid_tool_parameters_item_type_missing():
+    """Test validation fails when tool parameters item type is missing."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1211,13 +1211,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_missing():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1232,13 +1232,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_missing():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' is missing required field 'type' in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' is missing required field 'type' in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_type_not_string():
-    """Test validation fails when skill parameters item type is not a string."""
+def test_validate_definition_with_invalid_tool_parameters_item_type_not_string():
+    """Test validation fails when tool parameters item type is not a string."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1246,13 +1246,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_not_string(
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1267,13 +1267,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_not_string(
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' type must be a string in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' type must be a string in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_type_not_allowed():
-    """Test validation fails when skill parameters item type is not allowed."""
+def test_validate_definition_with_invalid_tool_parameters_item_type_not_allowed():
+    """Test validation fails when tool parameters item type is not allowed."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1281,13 +1281,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_not_allowed
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1304,13 +1304,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_type_not_allowed
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' type must be one of: string, number, integer, boolean, array in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' type must be one of: string, number, integer, boolean, array in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_required_type():
-    """Test validation fails when skill parameters item required is not a boolean."""
+def test_validate_definition_with_invalid_tool_parameters_item_required_type():
+    """Test validation fails when tool parameters item required is not a boolean."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1318,13 +1318,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_required_type():
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1347,13 +1347,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_required_type():
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' required field must be a boolean in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' required field must be a boolean in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_contact_field_type():
-    """Test validation fails when skill parameters item contact_field is not a boolean."""
+def test_validate_definition_with_invalid_tool_parameters_item_contact_field_type():
+    """Test validation fails when tool parameters item contact_field is not a boolean."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1361,13 +1361,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_ty
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1390,13 +1390,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_ty
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1' contact_field must be a boolean in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1' contact_field must be a boolean in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_contact_field_name():
-    """Test validation fails when skill parameters item contact_field is not a valid contact field name."""
+def test_validate_definition_with_invalid_tool_parameters_item_contact_field_name():
+    """Test validation fails when tool parameters item contact_field is not a valid contact field name."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1404,13 +1404,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1433,13 +1433,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        f"Agent 'test_agent': skill 'skill_1': parameter 'Param_1' name must match the regex of a valid contact field: {re.escape(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX)} in the agent definition file" # noqa W605
+        f"Agent 'test_agent': tool 'tool_1': parameter 'Param_1' name must match the regex of a valid contact field: {re.escape(ContactFieldValidator.CONTACT_FIELD_NAME_REGEX)} in the agent definition file" # noqa W605
         in error
     )
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_contact_field_name_length():
-    """Test validation fails when skill parameters item contact_field is not a valid contact field name."""
+def test_validate_definition_with_invalid_tool_parameters_item_contact_field_name_length():
+    """Test validation fails when tool parameters item contact_field is not a valid contact field name."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1447,13 +1447,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1476,13 +1476,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'param_1_with_a_very_long_name_that_exceeds_the_maximum_length_of_36_characters' name must be 36 characters or less in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'param_1_with_a_very_long_name_that_exceeds_the_maximum_length_of_36_characters' name must be 36 characters or less in the agent definition file"
         in error
     )
 
 
-def test_validate_definition_with_valid_skill_parameters_item_contact_field_name():
-    """Test validation passes when skill parameters item contact_field is a valid contact field name."""
+def test_validate_definition_with_valid_tool_parameters_item_contact_field_name():
+    """Test validation passes when tool parameters item contact_field is a valid contact field name."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1490,13 +1490,13 @@ def test_validate_definition_with_valid_skill_parameters_item_contact_field_name
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1520,8 +1520,8 @@ def test_validate_definition_with_valid_skill_parameters_item_contact_field_name
     assert error is None
 
 
-def test_validate_definition_with_invalid_skill_parameters_item_contact_field_name_reserved():
-    """Test validation fails when skill parameters item contact_field is a reserved contact field name."""
+def test_validate_definition_with_invalid_tool_parameters_item_contact_field_name_reserved():
+    """Test validation fails when tool parameters item contact_field is a reserved contact field name."""
     invalid_definition = {
         "agents": {
             "test_agent": {
@@ -1529,13 +1529,13 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
                 "description": "Test description",
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
-                "skills": [
+                "tools": [
                     {
-                        "skill_1": {
-                            "name": "Skill 1",
-                            "description": "Skill description",
+                        "tool_1": {
+                            "name": "Tool 1",
+                            "description": "Tool description",
                             "source": {
-                                "path": "path/to/skill",
+                                "path": "path/to/tool",
                                 "entrypoint": "entrypoint",
                                 "path_test": "path/to/test",
                             },
@@ -1558,7 +1558,7 @@ def test_validate_definition_with_invalid_skill_parameters_item_contact_field_na
     error = validate_agent_definition_schema(invalid_definition)
     assert error is not None
     assert (
-        "Agent 'test_agent': skill 'skill_1': parameter 'id' name must not be a reserved contact field name in the agent definition file"
+        "Agent 'test_agent': tool 'tool_1': parameter 'id' name must not be a reserved contact field name in the agent definition file"
         in error
     )
 
@@ -1705,7 +1705,7 @@ def test_validate_definition_with_valid_component_instructions():
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
                 "components": [{"type": "cta_message", "instructions": "test"}],
-                "skills": [{"skill_1": {"name": "Skill 1", "description": "Skill description", "source": {"path": "path/to/skill", "entrypoint": "entrypoint", "path_test": "path/to/test"}}}],
+                "tools": [{"tool_1": {"name": "Tool 1", "description": "Tool description", "source": {"path": "path/to/tool", "entrypoint": "entrypoint", "path_test": "path/to/test"}}}],
             }
         }
     }
@@ -1724,7 +1724,7 @@ def test_validate_definition_with_valid_component_and_no_instructions():
                 "instructions": SAMPLE_INSTRUCTIONS,
                 "guardrails": SAMPLE_GUARDRAILS,
                 "components": [{"type": "cta_message"}],
-                "skills": [{"skill_1": {"name": "Skill 1", "description": "Skill description", "source": {"path": "path/to/skill", "entrypoint": "entrypoint", "path_test": "path/to/test"}}}],
+                "tools": [{"tool_1": {"name": "Tool 1", "description": "Tool description", "source": {"path": "path/to/tool", "entrypoint": "entrypoint", "path_test": "path/to/test"}}}],
             }
         }
     }


### PR DESCRIPTION
- Updated the agent definition schema to use 'tools' instead of 'skills', reflecting a shift in terminology.
- Modified related test cases, validation logic, and file structure to accommodate the new 'tools' concept.
- Ensured all references to skills were replaced with tools across the codebase, including in the CLI commands and validation functions.
- Enhanced the initialization and project push processes to create and handle tool directories and files correctly.