### PR TITLE
Refactor CLIClient and related handlers to use 'tool_key' and 'agent_key' terminology

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -341,47 +341,6 @@ def test_run_command_tool_folder_failure(mocker, create_mocked_files, mock_store
         assert "Failed to load tool folder" in result.output
 
 
-def test_run_command_tool_name_error(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
-    """Test running a command when get_tool_and_agent_name returns None."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        agent_file = create_mocked_files()
-        _ = mock_store_values(mocker)  # Project UUID is saved in the mock
-        mock_tool_folder(mocker)
-
-        # Mock load_agent_definition to return valid data
-        mocker.patch(
-            "weni_cli.commands.run.load_agent_definition",
-            return_value=({"agents": {"get_address": {"description": "Test", "tools": []}}}, None),
-        )
-
-        # Mock load_test_definition to return valid data
-        mocker.patch("weni_cli.commands.run.load_test_definition", return_value=({"test_cases": []}, None))
-
-        # Patch the load_default_test_definition to return a valid file
-        mocker.patch(
-            "weni_cli.commands.run.RunHandler.load_default_test_definition",
-            return_value="tools/get_address/test_definition.yaml",
-        )
-
-        # Patch the load_tool_folder to return a mock folder
-        mocker.patch("weni_cli.commands.run.RunHandler.load_tool_folder", return_value=(b"mock_tool_folder", None))
-
-        # Make sure format_definition returns a valid definition
-        mocker.patch(
-            "weni_cli.commands.run.format_definition", return_value={"agents": {"get_address": {"tools": []}}}
-        )
-
-        # Patch the get_tool_and_agent_name to return None
-        mocker.patch("weni_cli.commands.run.RunHandler.get_tool_and_agent_name", return_value=(None, None))
-
-        result = runner.invoke(cli, ["run", agent_file, "get_address", "get_address"])
-
-        assert result.exit_code == 0
-        # Check the output directly for the error message
-        assert "Failed to get tool or agent name" in result.output
-
-
 def test_run_command_invalid_test_definition(mocker, create_mocked_files, mock_store_values, mock_tool_folder):
     """Test running a command when test definition file is invalid."""
     runner = CliRunner()
@@ -633,7 +592,7 @@ def test_load_tool_folder_success(mocker, create_mocked_files):
         result, error = handler.load_tool_folder(definition, "get_address", "get_address")
         assert result is not None
         assert error is None
-        mock_zip.assert_called_once_with("get-address", "tools/get_address")
+        mock_zip.assert_called_once_with("get_address", "tools/get_address")
 
 
 def test_load_tool_folder_agent_not_found():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -174,10 +174,6 @@ def test_run_command_success(mocker, create_mocked_files, mock_cli_response, moc
         mocker.patch("weni_cli.commands.run.RunHandler.get_tool_source_path", return_value="tools/get_address")
         mocker.patch("weni_cli.commands.run.RunHandler.load_tool_credentials", return_value={"API_KEY": "test_key"})
         mocker.patch("weni_cli.commands.run.RunHandler.load_tool_globals", return_value={"REGION": "us-east-1"})
-        mocker.patch(
-            "weni_cli.commands.run.RunHandler.get_tool_and_agent_name",
-            return_value=("Get Address", "Get Address Tool"),
-        )
 
         # Mock the CLIClient.run_test before the test
         mock_client_run = mocker.patch("weni_cli.clients.cli_client.CLIClient.run_test")
@@ -399,43 +395,6 @@ def test_parse_agent_tool_failure():
         agent_key, tool_key = handler.parse_agent_tool("invalid_format")
         assert agent_key is None
         assert tool_key is None
-
-
-def test_get_tool_and_agent_name_success():
-    """Test get_tool_and_agent_name with valid input."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        handler = RunHandler()
-
-        # Mock the definition to match our expected structure
-        formatted_definition = {
-            "agents": {
-                "get_address": {
-                    "name": "Get Address",
-                    "tools": [
-                        {
-                            "name": "Get Address Tool",
-                            "key": "get_address"
-                        }
-                    ]
-                }
-            }
-        }
-
-        agent_name, tool_name = handler.get_tool_and_agent_name(formatted_definition, "get_address", "get_address")
-        assert agent_name == "Get Address"
-        assert tool_name == "Get Address Tool"
-
-
-def test_get_tool_and_agent_name_failure():
-    """Test get_tool_and_agent_name with invalid input."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        handler = RunHandler()
-        definition = {"agents": {}}
-        agent_name, tool_name = handler.get_tool_and_agent_name(definition, "nonexistent", "nonexistent")
-        assert agent_name is None
-        assert tool_name is None
 
 
 def test_get_tool_source_path_success():

--- a/weni_cli/clients/cli_client.py
+++ b/weni_cli/clients/cli_client.py
@@ -192,8 +192,8 @@ class CLIClient:
         project_uuid: str,
         definition: Dict,
         tool_folder: BinaryIO,
-        tool_name: str,
-        agent_name: str,
+        tool_key: str,
+        agent_key: str,
         test_definition: Dict,
         credentials: Dict,
         tool_globals: Dict,
@@ -204,7 +204,7 @@ class CLIClient:
         test_logs = []
 
         data = self._prepare_test_data(
-            project_uuid, definition, test_definition, tool_name, agent_name, credentials, tool_globals
+            project_uuid, definition, test_definition, tool_key, agent_key, credentials, tool_globals
         )
         files = {"tool": tool_folder}
 
@@ -221,8 +221,8 @@ class CLIClient:
         project_uuid: str,
         definition: Dict,
         test_definition: Dict,
-        tool_name: str,
-        agent_name: str,
+        tool_key: str,
+        agent_key: str,
         credentials: Dict,
         tool_globals: Dict,
     ) -> Dict[str, str]:
@@ -231,8 +231,8 @@ class CLIClient:
         data.update(
             {
                 "test_definition": json.dumps(test_definition),
-                "tool_name": tool_name,
-                "agent_name": agent_name,
+                "tool_key": tool_key,
+                "agent_key": agent_key,
                 "tool_credentials": json.dumps(credentials),
                 "tool_globals": json.dumps(tool_globals),
             }

--- a/weni_cli/commands/project_push.py
+++ b/weni_cli/commands/project_push.py
@@ -1,8 +1,6 @@
 from typing import Optional
 import rich_click as click
 
-from slugify import slugify
-
 from weni_cli.formatter.formatter import Formatter
 from weni_cli.clients.cli_client import CLIClient
 from weni_cli.handler import Handler
@@ -51,17 +49,15 @@ class ProjectPushHandler(Handler):
 
         agents = definition.get("agents", {})
 
-        for _, agent_data in agents.items():
+        for agent_key, agent_data in agents.items():
             tools = agent_data.get("tools", {})
             for tool in tools:
-                for _, tool_data in tool.items():
-                    agent_name_slug = slugify(agent_data.get("name"))
-                    tool_slug = slugify(tool_data.get("name"))
-                    tool_folder, error = create_tool_folder_zip(tool_slug, tool_data.get("source").get("path"))
+                for tool_key, tool_data in tool.items():
+                    tool_folder, error = create_tool_folder_zip(tool_key, tool_data.get("source").get("path"))
                     if error:
                         return None, f"Failed to create tool folder for tool {tool_data.get('name')} in agent {agent_data.get('name')}\n{error}"
 
-                    tools_folder_map[f"{agent_name_slug}:{tool_slug}"] = tool_folder
+                    tools_folder_map[f"{agent_key}:{tool_key}"] = tool_folder
 
         return tools_folder_map, None
 

--- a/weni_cli/commands/run.py
+++ b/weni_cli/commands/run.py
@@ -86,22 +86,6 @@ class RunHandler(Handler):
         except Exception:
             return None, None
 
-    def get_tool_and_agent_name(self, definition, agent_key, tool_key) -> tuple[Optional[str], Optional[str]]:
-        agent_data = definition.get("agents", {}).get(agent_key)
-
-        print("Agent data: ", agent_data)
-
-        if not agent_data:
-            return None, None
-
-        tool_name = None
-        for tool in agent_data.get("tools", []):
-            print("Tool: ", tool)
-            if tool.get("key") == tool_key:
-                tool_name = tool.get("name")
-
-        return agent_data.get("name"), tool_name
-
     def get_tool_source_path(self, definition, agent_key, tool_key) -> Optional[str]:
         agent_data = definition.get("agents", {}).get(agent_key)
 

--- a/weni_cli/commands/run.py
+++ b/weni_cli/commands/run.py
@@ -2,8 +2,6 @@ from io import BufferedReader
 from typing import Optional
 import rich_click as click
 
-from slugify import slugify
-
 from rich.console import Console
 from rich.table import Table
 from rich.live import Live
@@ -70,18 +68,12 @@ class RunHandler(Handler):
 
         tool_globals = self.load_tool_globals(tool_source_path)
 
-        agent_name, tool_name = self.get_tool_and_agent_name(definition, agent_key, tool_key)
-
-        if not tool_name or not agent_name:
-            click.echo("Error: Failed to get tool or agent name")
-            return
-
         self.run_test(
             project_uuid,
             definition,
             tool_folder,
-            tool_name,
-            agent_name,
+            tool_key,
+            agent_key,
             test_definition,
             credentials,
             tool_globals,
@@ -189,8 +181,7 @@ class RunHandler(Handler):
         if not tool_data:
             return None, Exception(f"Tool {tool_key} not found in agent {agent_key}")
 
-        tool_slug = slugify(tool_data.get("name"))
-        tool_folder, error = create_tool_folder_zip(tool_slug, tool_data.get("source").get("path"))
+        tool_folder, error = create_tool_folder_zip(tool_key, tool_data.get("source").get("path"))
         if error:
             return None, Exception(f"Failed to create tool folder for tool {tool_key} in agent {agent_key}\n{error}")
 
@@ -319,8 +310,8 @@ class RunHandler(Handler):
         project_uuid,
         definition,
         tool_folder,
-        tool_name,
-        agent_name,
+        tool_key,
+        agent_key,
         test_definition,
         credentials,
         tool_globals,
@@ -328,11 +319,11 @@ class RunHandler(Handler):
     ):
         test_rows = []
         # Use the class method instead of a nested function
-        with Live(self.display_test_results([], tool_name, verbose), refresh_per_second=4) as live:
+        with Live(self.display_test_results([], tool_key, verbose), refresh_per_second=4) as live:
             # Create a callback function that will be passed to the CLIClient
             def update_live_callback(test_name, test_result, status_code, code, verbose):
                 self.update_live_display(
-                    test_rows, test_name, test_result, status_code, code, live, tool_name, verbose
+                    test_rows, test_name, test_result, status_code, code, live, tool_key, verbose
                 )
 
             client = CLIClient()
@@ -340,8 +331,8 @@ class RunHandler(Handler):
                 project_uuid,
                 definition,
                 tool_folder,
-                tool_name,
-                agent_name,
+                tool_key,
+                agent_key,
                 test_definition,
                 credentials,
                 tool_globals,

--- a/weni_cli/packager/packager.py
+++ b/weni_cli/packager/packager.py
@@ -5,8 +5,8 @@ from typing import Optional
 from zipfile import ZipFile
 
 
-def create_tool_folder_zip(tool_name, tool_path) -> tuple[Optional[BufferedReader], Optional[Exception]]:
-    zip_file_name = f"{tool_name}.zip"
+def create_tool_folder_zip(tool_key, tool_path) -> tuple[Optional[BufferedReader], Optional[Exception]]:
+    zip_file_name = f"{tool_key}.zip"
     zip_file_path = f"{tool_path}{os.sep}{zip_file_name}"
 
     if not os.path.exists(tool_path):

--- a/weni_cli/validators/definition.py
+++ b/weni_cli/validators/definition.py
@@ -272,11 +272,11 @@ def format_definition(definition: dict) -> Optional[dict]:
         tools = agents[agent].get("tools", {})
         agent_tools = []
         for tool in tools:
-            for tool_name, tool_data in tool.items():
+            for tool_key, tool_data in tool.items():
                 tool_slug = slugify(tool_data.get("name"))
                 agent_tools.append(
                     {
-                        "key": tool_name,
+                        "key": tool_key,
                         "slug": tool_slug,
                         "name": tool_data.get("name"),
                         "source": tool_data.get("source"),


### PR DESCRIPTION
- Updated CLIClient methods to replace 'tool_name' and 'agent_name' with 'tool_key' and 'agent_key' for consistency.
- Adjusted ProjectPushHandler and RunHandler to reflect the new key names in tool and agent processing.
- Modified the create_tool_folder_zip function to align with the updated terminology.
- Ensured all references in the validation logic are updated accordingly.
- Updated test_load_tool_folder_success to correct the assertion for tool key.