### PR TITLE
Refactor documentation and codebase to transition from 'skills' to 't…

### DIFF
--- a/docs/core-concepts/agents.md
+++ b/docs/core-concepts/agents.md
@@ -33,7 +33,7 @@ agents:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddress"
             path_test: "tests.yaml"
           description: "Function to get the address from the postal code"
@@ -72,42 +72,42 @@ agents:
     :   You can list boundaries and limitations for your agent, such as topics it should not discuss.  
         **Limit**: :octicons-alert-24: Minimum of 40 characters.
 
-=== "Skill"
+=== "Tool"
 
     `Name`
 
-    :   The name of the skill that will be associated with the agent in the Weni Platform.  
+    :   The name of the tool that will be associated with the agent in the Weni Platform.  
         **Limit**: :octicons-alert-24: Maximum of 53 characters
 
     `Source`
 
-    :   The location or path where the skill can be found. It contains three important elements:
+    :   The location or path where the tool can be found. It contains three important elements:
         
-        - `path`: The directory path where your skill's code is located. This is typically a relative path from the root of your project.
+        - `path`: The directory path where your tool's code is located. This is typically a relative path from the root of your project.
         
-        - `entrypoint`: The specific class that will be executed when the skill is called. It follows the format "file_name.ClassName". You can see a practical example of the skill implementation for this entrypoint in the [example](/core-concepts/skills) page, where the GetAddress class from this example is implemented.
+        - `entrypoint`: The specific class that will be executed when the tool is called. It follows the format "file_name.ClassName". You can see a practical example of the tool implementation for this entrypoint in the [example](/core-concepts/skills) page, where the GetAddress class from this example is implemented.
         
-        - `path_test`: The location of the test file for your skill, which contains test cases to validate the skill's functionality.
+        - `path_test`: The location of the test file for your tool, which contains test cases to validate the tool's functionality.
 
     `Description`
 
-    :   Information about the skill, including its purpose and objectives.
+    :   Information about the tool, including its purpose and objectives.
 
     `Parameters`
 
-    :   The parameters or variables used in your agent's skill.
+    :   The parameters or variables used in your agent's tool.
         
         - `description`: A clear explanation of what the parameter is used for and what kind of data it expects.
         
         - `type`: The data type of the parameter (e.g., string, integer, boolean, object).
         
-        - `required`: A boolean value (true/false) indicating whether the parameter must be provided for the skill to function properly. If set to true, the agent will ask the user for this information if it's not available before proceeding with the request.
+        - `required`: A boolean value (true/false) indicating whether the parameter must be provided for the tool to function properly. If set to true, the agent will ask the user for this information if it's not available before proceeding with the request.
         
         - `contact_field`: Specifies if the parameter should be stored as a contact field in the user's profile for future reference. If set to true, the respective parameter will become information that persists for the user integrated with the Weni Platform. This brings benefits to the user experience because in future interactions, your agent may not need to request this information from the user again. Read more about contact fields in [Contact Fields](./contact-fields.md).
 
 ## Basic Structure
 
-The basic structure of your project should consist of your agent definition written in YAML and your agent's skills organized into directories. It is not mandatory to organize your skills in a 'skills' directory, but it is highly recommended as a best practice.
+The basic structure of your project should consist of your agent definition written in YAML and your agent's tools organized into directories. It is not mandatory to organize your tools in a 'tools' directory, but it is highly recommended as a best practice.
 
 Based on the definition example below:
 
@@ -125,7 +125,7 @@ agents:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddress"
             path_test: "tests.yaml"
           description: "Function to get the address from the postal code"
@@ -140,7 +140,7 @@ agents:
 Your project should have the following structure:
 ```
 your-project-name/
-├── skills/
+├── tools/
 │   ├── get_address/main.py
 └── agent_definition.yaml
 ```

--- a/docs/core-concepts/credentials.md
+++ b/docs/core-concepts/credentials.md
@@ -64,11 +64,11 @@ When your agent is deployed on the Weni Platform, credentials are securely manag
 >         - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
 >         guardrails:
 >         - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
->         skills:
+>         tools:
 >         - get_address:
 >             name: "Get Address"
 >             source:
->                 path: "skills/get_address"
+>                 path: "tools/get_address"
 >                 entrypoint: "main.GetAddress"
 >                 path_test: "test_definition.yaml"
 >             description: "Function to get the address from the postal code"

--- a/docs/core-concepts/tools.md
+++ b/docs/core-concepts/tools.md
@@ -1,12 +1,12 @@
-# Skills
+# Tools
 
-## What Are Skills?
+## What Are Tools?
 
-Skills are powerful tools available to your agent that enable it to interact with the external environment and the real world. Think of skills as superpowers for your agent - you can create virtually any capability your agent needs by writing Python code that implements your specific business logic!
+Tools are powerful tools available to your agent that enable it to interact with the external environment and the real world. Think of tools as superpowers for your agent - you can create virtually any capability your agent needs by writing Python code that implements your specific business logic!
 
-## Why Skills Matter
+## Why Tools Matter
 
-Skills transform your agent from a simple conversational interface into a powerful tool that can:
+Tools transform your agent from a simple conversational interface into a powerful tool that can:
 
 - Fetch real-time data from external APIs
 - Perform complex calculations and data processing
@@ -15,23 +15,23 @@ Skills transform your agent from a simple conversational interface into a powerf
 - Integrate with third-party services and platforms
 - Automate tasks and workflows
 
-## Using Skills in Your Agent
+## Using Tools in Your Agent
 
-Once you've created a skill, you can relate it to your agent by defining it in your agent's YAML configuration file, as demonstrated in the [Agents](./agents.md) documentation page. The agent will automatically detect when to use the skill based on the context of the conversation.
+Once you've created a tool, you can relate it to your agent by defining it in your agent's YAML configuration file, as demonstrated in the [Agents](./agents.md) documentation page. The agent will automatically detect when to use the tool based on the context of the conversation.
 
-By creating custom skills, you can extend your agent's capabilities to handle specific tasks relevant to your use case, making your agent truly tailored to your business needs.
+By creating custom tools, you can extend your agent's capabilities to handle specific tasks relevant to your use case, making your agent truly tailored to your business needs.
 
-## Skill Example: Address Lookup
+## Tool Example: Address Lookup
 
-Here's an example of a skill that allows an agent to interact with the real world to precisely obtain information about a postal code (CEP in Brazil):
+Here's an example of a tool that allows an agent to interact with the real world to precisely obtain information about a postal code (CEP in Brazil):
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
-class GetAddress(Skill):
+class GetAddress(Tool):
     def execute(self, context: Context) -> TextResponse:
         
         cep = context.parameters.get("cep", "")
@@ -59,14 +59,14 @@ class GetAddress(Skill):
     If you're new to programming, here's a simpler explanation of what this code does:
 
     1. **Imports**: First, we bring in the tools we need:
-       - `Skill`: The base class that gives our skill its core functionality
+       - `Tool`: The base class that gives our tool its core functionality
        - `Context`: Holds information about the conversation
        - `TextResponse`: Helps us send text back to the user
        - `requests`: A tool that lets us get information from websites
 
-    2. **Class Definition**: We create a new skill called `GetAddress` that can look up addresses.
+    2. **Class Definition**: We create a new tool called `GetAddress` that can look up addresses.
 
-    3. **Execute Method**: This is the main part that runs when someone uses the skill:
+    3. **Execute Method**: This is the main part that runs when someone uses the tool:
        - It gets the postal code (CEP) that the user provided
        - It prints the CEP to help with debugging
        - It calls another function to find the address for that CEP
@@ -78,15 +78,15 @@ class GetAddress(Skill):
        - Sends a request to a website that knows about addresses
        - Gets back information about the address and returns it
 
-    Think of this skill like a helper that knows how to look up addresses in a phone book when you give it a postal code!
+    Think of this tool like a helper that knows how to look up addresses in a phone book when you give it a postal code!
 
 === "For Experienced Developers"
 
     For those familiar with Python and API development:
 
-    1. **Imports**: We import the necessary Weni framework classes (`Skill`, `Context`, `TextResponse`) and the `requests` library for HTTP operations.
+    1. **Imports**: We import the necessary Weni framework classes (`Tool`, `Context`, `TextResponse`) and the `requests` library for HTTP operations.
 
-    2. **Class Definition**: We define a `GetAddress` class that inherits from the base `Skill` class, which provides the framework integration.
+    2. **Class Definition**: We define a `GetAddress` class that inherits from the base `Tool` class, which provides the framework integration.
 
     3. **Execute Method**: This is the entry point that the Weni framework calls:
        - It extracts the "cep" parameter from the context object using a get() with a default empty string
@@ -102,35 +102,35 @@ class GetAddress(Skill):
 
     This implementation follows a simple separation of concerns pattern but could be enhanced with error handling, input validation, response formatting, and proper logging for production use.
 
-## Creating Your Own Skills
+## Creating Your Own Tools
 
-To create your own skill:
+To create your own tool:
 
-1. **Define Your Skill Class**: Create a new Python class that inherits from `Skill`
+1. **Define Your Tool Class**: Create a new Python class that inherits from `Tool`
 2. **Implement the Execute Method**: Override the `execute(self, context: Context)` method with your business logic
 3. **Add Helper Methods**: Separate concerns by breaking down complex logic into helper methods
 4. **Implement Error Handling**: Add robust error handling for API calls, data processing, and edge cases
 5. **Add Logging**: Include appropriate logging for monitoring and debugging
 6. **Write Tests**: Create comprehensive test cases using the test file specified in `path_test`
-7. **Configure Your Skill**: Add your skill to your agent's YAML configuration with appropriate parameters and any credentials required by your skill.
+7. **Configure Your Tool**: Add your tool to your agent's YAML configuration with appropriate parameters and any credentials required by your tool.
 
-## Skills with Credentials
+## Tools with Credentials
 
-When your skill needs to interact with external services that require authentication, you'll need to use credentials or secrets. The Weni framework provides a secure way to manage these credentials through the `Context` object.
+When your tool needs to interact with external services that require authentication, you'll need to use credentials or secrets. The Weni framework provides a secure way to manage these credentials through the `Context` object.
 
 ### How to Access Credentials
 
-Credentials are accessed through the `Context` object that is passed to your skill's `execute` method. This ensures that sensitive information is handled securely and isn't hardcoded in your skill's code.
+Credentials are accessed through the `Context` object that is passed to your tool's `execute` method. This ensures that sensitive information is handled securely and isn't hardcoded in your tool's code.
 
-Here's an example of how to modify our `GetAddress` skill to use credentials for an API that requires authentication:
+Here's an example of how to modify our `GetAddress` tool to use credentials for an API that requires authentication:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
-class GetAddressWithAuth(Skill):
+class GetAddressWithAuth(Tool):
     def execute(self, context: Context) -> TextResponse:
         cep = context.parameters.get("cep", "")
         
@@ -154,7 +154,7 @@ class GetAddressWithAuth(Skill):
 
 ### Configuring Credentials in Your Agent Definition
 
-To make credentials available to your skill, you need to define them in your agent's YAML configuration file. Here's an example:
+To make credentials available to your tool, you need to define them in your agent's YAML configuration file. Here's an example:
 
 ```yaml
 agents:
@@ -170,11 +170,11 @@ agents:
       - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
     guardrails:
       - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
-    skills:
+    tools:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddressWithAuth"
             path_test: "tests.yaml"
           description: "Function to get the address from the postal code"
@@ -190,22 +190,22 @@ agents:
 
 ### Best Practices for Handling Credentials
 
-When working with credentials in your skills:
+When working with credentials in your tools:
 
-1. **Never hardcode credentials** in your skill's code.
+1. **Never hardcode credentials** in your tool's code.
 2. **Always access credentials through the Context object**.
 3. **Use environment variables** for local development and testing.
 4. **Implement proper error handling** for cases where credentials might be missing or invalid.
 
-By following these practices, you can create secure skills that interact with authenticated services while keeping sensitive information protected.
+By following these practices, you can create secure tools that interact with authenticated services while keeping sensitive information protected.
 
-## Best Practices for Skills
+## Best Practices for Tools
 
-When creating skills, follow these best practices:
+When creating tools, follow these best practices:
 
-- **Single Responsibility**: Each skill should have a clear, focused purpose
+- **Single Responsibility**: Each tool should have a clear, focused purpose
 - **Comprehensive Error Handling**: Implement robust error handling for all external calls and edge cases
 - **Input Validation**: Validate all input parameters before processing
 - **Security Considerations**: Handle sensitive data appropriately and follow security best practices
-- **Testability**: Design your skills to be easily testable with both unit and integration tests
-- **Version Control**: Use a GitHub repository to version your skills, allowing you to track changes, collaborate with others, and easily roll back to previous versions if needed
+- **Testability**: Design your tools to be easily testable with both unit and integration tests
+- **Version Control**: Use a GitHub repository to version your tools, allowing you to track changes, collaborate with others, and easily roll back to previous versions if needed

--- a/docs/examples/book-agent.md
+++ b/docs/examples/book-agent.md
@@ -25,11 +25,11 @@ agents:
         - "Provide accurate and verified information"
         - "When translating, maintain fidelity to the original text meaning"
         - "Mention when rating or page count information is not available"
-      skills:
+      tools:
       - get_books:
           name: "Search Books"
           source:
-            path: "skills/get_books"
+            path: "tools/get_books"
             entrypoint: "books.GetBooks"
             path_test: "test_definition.yaml"
           description: "Function to search for book information"
@@ -41,25 +41,25 @@ agents:
                 contact_field: true
 ```
 
-## Skill Implementation
+## Tool Implementation
 
-Create a file `skills/get_books/books.py`:
+Create a file `tools/get_books/books.py`:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 from datetime import datetime
 
 
-class GetBooks(Skill):
+class GetBooks(Tool):
     def execute(self, context: Context) -> TextResponse:
         apiKey = context.credentials.get("apiKey")
         
         book_title = context.parameters.get("book_title", "")
         books_response = self.get_books_by_title(title=book_title)
-        
+
         # Format the response
         items = books_response.get("items", [])
         if not items:
@@ -102,13 +102,13 @@ class GetBooks(Skill):
         return response.json()
 ```
 
-Create a file `skills/get_books/requirements.txt`:
+Create a file `tools/get_books/requirements.txt`:
 
 ```
 requests==2.32.3
 ```
 
-Create a file `skills/get_books/test_definition.yaml`:
+Create a file `tools/get_books/test_definition.yaml`:
 
 ```yaml
 tests:
@@ -117,11 +117,11 @@ tests:
             book_title: "The Hobbit"
 ```
 
-## Testing the Skill Locally
+## Testing the Tool Locally
 
-Before deploying your agent, you can test the skill locally using the `weni run` command. This allows you to verify that your skill works correctly and debug any issues.
+Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-To test the Book Agent skill:
+To test the Book Agent tool:
 
 ```bash
 weni run agent_definition.yaml book_agent get_books
@@ -135,7 +135,7 @@ If you need more detailed logs for debugging, you can add the `-v` flag:
 weni run agent_definition.yaml book_agent get_books -v
 ```
 
-The verbose output will show you more details about the execution process, helping you identify and fix any issues with your skill.
+The verbose output will show you more details about the execution process, helping you identify and fix any issues with your tool.
 
 ## Deployment Steps
 

--- a/docs/examples/cep-agent.md
+++ b/docs/examples/cep-agent.md
@@ -16,11 +16,11 @@ agents:
       - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
     guardrails:
       - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
-    skills:
+    tools:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddress"
             path_test: "test_definition.yaml"
           description: "Function to get the address from the postal code"
@@ -32,18 +32,18 @@ agents:
                 contact_field: true
 ```
 
-## Skill Implementation
+## Tool Implementation
 
-Create a file `skills/get_address/main.py`:
+Create a file `tools/get_address/main.py`:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
 
-class GetAddress(Skill):
+class GetAddress(Tool):
     def execute(self, context: Context) -> TextResponse:
         cep = context.parameters.get("cep", "")
         address_response = self.get_address_by_cep(cep=cep)
@@ -55,13 +55,13 @@ class GetAddress(Skill):
         return response.json()
 ```
 
-Create a file `skills/get_address/requirements.txt`:
+Create a file `tools/get_address/requirements.txt`:
 
 ```
 requests==2.31.0
 ```
 
-Create a file `skills/get_address/test_definition.yaml`:
+Create a file `tools/get_address/test_definition.yaml`:
 
 ```yaml
 tests:
@@ -76,14 +76,14 @@ tests:
             cep: "20050-090"
 ```
 
-## Testing the Skill Locally
+## Testing the Tool Locally
 
-Before deploying your agent, you can test the skill locally using the `weni run` command. This allows you to verify that your skill works correctly and debug any issues.
+Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-To test the CEP Agent skill:
+To test the CEP Agent tool:
 
 ```bash
-weni run agents.yaml sample_agent get_address
+weni run agent_definition.yaml cep_agent get_address
 ```
 
 This command will execute the tests defined in the `test_definition.yaml` file and show you the output. You should see the address information for the Brazilian postal codes specified in the test cases.
@@ -91,10 +91,10 @@ This command will execute the tests defined in the `test_definition.yaml` file a
 If you need more detailed logs for debugging, you can add the `-v` flag:
 
 ```bash
-weni run agents.yaml sample_agent get_address -v
+weni run agent_definition.yaml cep_agent get_address -v
 ```
 
-The verbose output will show you more details about the execution process, including the API requests and responses, helping you identify and fix any issues with your skill.
+This will run the test cases defined in `test_definition.yaml` and show you the output, helping you identify and fix any issues with your tool.
 
 ## Deployment Steps
 

--- a/docs/examples/movie-agent.md
+++ b/docs/examples/movie-agent.md
@@ -31,14 +31,14 @@ agents:
         - "Provide accurate and verified information"
         - "When translating, maintain fidelity to the original text meaning"
         - "If there's doubt in title translation, use the most internationally known name"
-    skills:
-    - get_movies_new:
-        name: "Search Movies New"
-        source:
-          path: "skills/get_movies"
+    tools:
+    - get_movies:
+        name: "Get Movies"
+        source: 
+          path: "tools/get_movies"
           entrypoint: "main.GetMovies"
           path_test: "test_definition.yaml"
-        description: "Function to search for movie information"
+        description: "Function to get movie information from TMDB API"
         parameters:
             - movie_title:
                 description: "movie title to search for (will be translated to English if in Portuguese)"
@@ -47,19 +47,18 @@ agents:
                 contact_field: true
 ```
 
-## Skill Implementation
+## Tool Implementation
 
-Create a file `skills/get_movies/main.py`:
+Create a file `tools/get_movies/main.py`:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 from datetime import datetime
 
-
-class GetMovies(Skill):
+class GetMovies(Tool):
     def execute(self, context: Context) -> TextResponse:
         movie_title = context.parameters.get("movie_title", "")
         api_key = context.credentials.get("movies_api_key")
@@ -117,13 +116,13 @@ class GetMovies(Skill):
         return response.json()
 ```
 
-Create a file `skills/get_movies/requirements.txt`:
+Create a file `tools/get_movies/requirements.txt`:
 
 ```
 requests==2.32.3
 ```
 
-Create a file `skills/get_movies/test_definition.yaml`:
+Create a file `tools/get_movies/test_definition.yaml`:
 
 ```yaml
 tests:
@@ -144,20 +143,20 @@ For this agent to work properly, you'll need to get an API key from The Movie Da
 4. Copy your API key
 5. When deploying the agent, you'll need to provide this key as a credential
 
-## Testing the Skill Locally
+## Testing the Tool Locally
 
-Before deploying your agent, you can test the skill locally using the `weni run` command. This allows you to verify that your skill works correctly and debug any issues.
+Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-Since this skill requires credentials, you'll need to create a `.env` file in the root of your project with your TMDB API key:
+Since this tool requires credentials, you'll need to create a `.env` file in the root of your project with your TMDB API key:
 
 ```
 movies_api_key=your_actual_tmdb_api_key_here
 ```
 
-To test the Movie Agent skill:
+To test the Movie Agent tool:
 
 ```bash
-weni run agent_definition.yaml movie_agent get_movies_new
+weni run agent_definition.yaml movie_agent get_movies
 ```
 
 This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the `.env` file and make them available to your skill during execution.
@@ -165,10 +164,10 @@ This command will execute the tests defined in the `test_definition.yaml` file a
 If you need more detailed logs for debugging, you can add the `-v` flag:
 
 ```bash
-weni run agent_definition.yaml movie_agent get_movies_new -v
+weni run agent_definition.yaml movie_agent get_movies -v
 ```
 
-The verbose output will show you more details about the execution process, including API requests and responses, helping you identify and fix any issues with your skill.
+The verbose output will show you more details about the execution process, including API requests and responses, helping you identify and fix any issues with your tool.
 
 ## Deployment Steps
 

--- a/docs/examples/news-agent.md
+++ b/docs/examples/news-agent.md
@@ -25,25 +25,25 @@ agents:
             - "Maintain a professional and impartial tone when presenting news"
             - "Don't make assumptions or speculations about the news"
             - "Avoid sharing sensationalist or unverified news"
-        skills:
+        tools:
         - get_news:
             name: "Get News"
             source:
-                path: "skills/get_news"
+                path: "tools/get_news"
                 entrypoint: "main.GetNews"
                 path_test: "test_definition.yaml"
-            description: "Function to search news about a specific topic"
+            description: "Function to get the latest news from NewsAPI"
             parameters:
                 - topic:
-                    description: "topic to search news about"
+                    description: "Topic to search for news"
                     type: "string"
                     required: true
                     contact_field: true
 ```
 
-## Skill Implementation
+## Tool Implementation
 
-Create a file `skills/get_news/main.py`:
+Create a file `tools/get_news/main.py`:
 
 ```python
 from weni import Skill
@@ -99,13 +99,13 @@ class GetNews(Skill):
         return response.json()
 ```
 
-Create a file `skills/get_news/requirements.txt`:
+Create a file `tools/get_news/requirements.txt`:
 
 ```
 requests==2.32.3
 ```
 
-Create a file `skills/get_news/test_definition.yaml`:
+Create a file `tools/get_news/test_definition.yaml`:
 
 ```yaml
 tests:
@@ -125,23 +125,23 @@ For this agent to work properly, you'll need to get an API key from News API:
 3. Copy your API key from your account
 4. When deploying the agent, you'll need to provide this key as a credential
 
-## Testing the Skill Locally
+## Testing the Tool Locally
 
-Before deploying your agent, you can test the skill locally using the `weni run` command. This allows you to verify that your skill works correctly and debug any issues.
+Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-Since this skill requires credentials, you'll need to create a `.env` file in the root of your project with your API key:
+Since this tool requires credentials, you'll need to create a `.env` file in the root of your project with your API key:
 
 ```
 apiKey=your_actual_news_api_key_here
 ```
 
-To test the News Agent skill:
+To test the News Agent tool:
 
 ```bash
 weni run agent_definition.yaml news_agent get_news
 ```
 
-This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the `.env` file and make them available to your skill during execution.
+This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the `.env` file and make them available to your tool during execution.
 
 If you need more detailed logs for debugging, you can add the `-v` flag:
 
@@ -149,7 +149,7 @@ If you need more detailed logs for debugging, you can add the `-v` flag:
 weni run agent_definition.yaml news_agent get_news -v
 ```
 
-The verbose output will show you more details about the execution process, helping you identify and fix any issues with your skill.
+The verbose output will show you more details about the execution process, helping you identify and fix any issues with your tool.
 
 ## Deployment Steps
 

--- a/docs/getting-started/quickstart-developers.md
+++ b/docs/getting-started/quickstart-developers.md
@@ -47,7 +47,7 @@ Before you begin, make sure you have:
 weni init
 ```
 
-This command will create a new agent with the name `cep_agent` and the skill `get_address`.
+This command will create a new agent with the name `cep_agent` and the tool `get_address`.
 
 #### 2.1. Agent Configuration
 
@@ -63,11 +63,11 @@ agents:
       - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
     guardrails:
       - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
-    skills:
+    tools:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddress"
           description: "Function to get the address from the postal code"
           parameters:
@@ -83,49 +83,49 @@ In the YAML above, note the `source` field:
 
 ```yaml
 source: 
-  path: "skills/get_address"
+  path: "tools/get_address"
   entrypoint: "main.GetAddress"
 ```
 
-- **path**: Specifies the directory containing your skill implementation
-  - `skills/get_address` means a folder named `get_address` inside a `skills` directory
+- **path**: Specifies the directory containing your tool implementation
+  - `tools/get_address` means a folder named `get_address` inside a `tools` directory
   - This is where your Python files and requirements.txt should be located
 
 - **entrypoint**: Tells the system which class to use
   - `main.GetAddress` means:
     - Find a file named `main.py` in the path directory
     - Use the `GetAddress` class inside that file
-    - The class must inherit from the `Skill` base class
+    - The class must inherit from the `Tool` base class
 
 Your project structure should look like:
 ```
 my-agent-project/
 ├── agents.yaml
-└── skills/
+└── tools/
     └── get_address/
         ├── main.py             # Contains GetAddress class
         └── requirements.txt    # Dependencies
 ```
 
-#### 2.2. Skill Implementation
+#### 2.2. Tool Implementation
 
-1. **Create Skill Directory**
+1. **Create Tool Directory**
    ```bash
-   mkdir -p skills/get_address
-   cd skills/get_address
+   mkdir -p tools/get_address
+   cd tools/get_address
    ```
 
-2. **Create Skill Class**
-   Create a file `skills/get_address/main.py`:
+2. **Create Tool Class**
+   Create a file `tools/get_address/main.py`:
 
    ```python
-   from weni import Skill
+   from weni import Tool
    from weni.context import Context
    from weni.responses import TextResponse
    import requests
 
 
-   class GetAddress(Skill):
+   class GetAddress(Tool):
        def execute(self, context: Context) -> TextResponse:
            cep = context.parameters.get("cep", "")
            address_response = self.get_address_by_cep(cep=cep)
@@ -140,7 +140,7 @@ my-agent-project/
    **Important**: 
    - The class name `GetAddress` must match the class name in your entrypoint
    - The file name `main.py` must match the file name in your entrypoint
-   - The class must inherit from `Skill` and implement the `execute` method
+   - The class must inherit from `Tool` and implement the `execute` method
 
 3. **Create Requirements File**
    Create a `requirements.txt` file:
@@ -159,7 +159,7 @@ weni project push agents.yaml
 
 ### Custom Parameters
 
-You can add more parameters to your skills:
+You can add more parameters to your tools:
 
 ```yaml
 parameters:
@@ -170,14 +170,14 @@ parameters:
       default: "json"
 ```
 
-### Multiple Skills
+### Multiple Tools
 
-Agents can have multiple skills:
+Agents can have multiple tools:
 
 ```yaml
-skills:
+tools:
   - get_address:
-      # skill definition
+      # tool definition
   - validate_cep:
-      # another skill definition
+      # another tool definition
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Weni CLI is a command-line tool that simplifies the creation and management of m
 With it, you can:
 
 - [x] Create AI agents
-- [x] Add custom skills to your agents
+- [x] Add custom tools to your agents
 - [x] Deploy agents
 - [x] Update agent configurations and behaviors
 - [x] Manage multiple agents in your projects

--- a/docs/run/tool-run.md
+++ b/docs/run/tool-run.md
@@ -1,19 +1,19 @@
-# Skill Run
+# Tool Run
 
-Skill Run is a scalable way to build your skill and test it in real-time. With this feature, it's simple to debug problems and create a skill that is both scalable and performant at the same time.
+Tool Run is a scalable way to build your tool and test it in real-time. With this feature, it's simple to debug problems and create a tool that is both scalable and performant at the same time.
 
-## What is required to run a skill?
+## What is required to run a tool?
 
-First, you need to have your skill. If you don't know how to create a skill or still have questions about this subject, you can read the skills page [Skills](../core-concepts/skills.md).
+First, you need to have your tool. If you don't know how to create a tool or still have questions about this subject, you can read the tools page [Tools](../core-concepts/tools.md).
 
-Next, you need to write your test. Let's take the following skill as an example:
+Next, you need to write your test. Let's take the following tool as an example:
 
 ```yaml
-skills:
+tools:
   - get_address:
       name: "Get Address"
       source: 
-        path: "skills/get_address"
+        path: "tools/get_address"
         entrypoint: "main.GetAddressWithAuth"
         path_test: "test.yaml"
       description: "Function to get the address from the postal code"
@@ -25,7 +25,7 @@ skills:
             contact_field: true
 ```
 
-Notice that my skill has a specific parameter called "cep". Therefore, the expected input for this skill to be processed is a postal code. This way, I'll create a test file for this skill in the same directory as the specific skill code.
+Notice that my tool has a specific parameter called "cep". Therefore, the expected input for this tool to be processed is a postal code. This way, I'll create a test file for this tool in the same directory as the specific tool code.
 
 My test file would look something like this:
 
@@ -44,9 +44,9 @@ tests:
             cep: "57160-000"
 ```
 
-Make sure that `path_test` corresponds to the correct path of your skill test.
+Make sure that `path_test` corresponds to the correct path of your tool test.
 
-It's also important to note that if your skill uses any external libraries, you must include a `requirements.txt` file in the same directory as your skill code. This file should list all the dependencies needed for your skill to run properly.
+It's also important to note that if your tool uses any external libraries, you must include a `requirements.txt` file in the same directory as your tool code. This file should list all the dependencies needed for your tool to run properly.
 
 ## How to run a test?
 
@@ -55,7 +55,7 @@ Following the previous steps, we can now run a test, but how?
 The command works as follows:
 
 ```
-weni run [agent definition file] [agent name] [skill name]
+weni run [agent definition file] [agent name] [tool name]
 ```
 
 A practical example of the command considering the agent definition that was mentioned above would be:
@@ -68,7 +68,7 @@ Result:
 
 ![Run Default](../assets/run-no-v.png)
 
-There is also a variation of this command in case you need to include ways to debug the code. You can add the `-v` argument at the end of the command to get more detailed logs of your skill, like this:
+There is also a variation of this command in case you need to include ways to debug the code. You can add the `-v` argument at the end of the command to get more detailed logs of your tool, like this:
 
 ```
 weni run agent_definition.yaml cep_agent get_address -v
@@ -78,9 +78,9 @@ Result:
 
 ![Run with logs](../assets/run-with-v.png)
 
-## Running Skills That Require Credentials
+## Running Tools That Require Credentials
 
-When your skill needs to interact with external services that require authentication, you'll need to provide credentials during testing. The official method for handling credentials with weni run is using your agent definition and a .env file.
+When your tool needs to interact with external services that require authentication, you'll need to provide credentials during testing. The official method for handling credentials with weni run is using your agent definition and a .env file.
 
 ### Using Agent Definition and .env File
 
@@ -102,11 +102,11 @@ agents:
       - "The user will send a ZIP code (postal code) and you must provide the address corresponding to this code."
     guardrails:
       - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."
-    skills:
+    tools:
       - get_address:
           name: "Get Address"
           source: 
-            path: "skills/get_address"
+            path: "tools/get_address"
             entrypoint: "main.GetAddressWithAuth"
             path_test: "test.yaml"
           description: "Function to get the address from the postal code"
@@ -124,25 +124,25 @@ Then, create a `.env` file in the root of your project with the actual credentia
 api_key=your_actual_api_key_here
 ```
 
-Now you can run your skill test with credentials using the same command:
+Now you can run your tool test with credentials using the same command:
 
 ```
 weni run agent_definition.yaml cep_agent get_address
 ```
 
-The CLI will automatically pick up the credentials from the `.env` file and make them available to your skill during execution.
+The CLI will automatically pick up the credentials from the `.env` file and make them available to your tool during execution.
 
-### Accessing Credentials in Your Skill Code
+### Accessing Credentials in Your Tool Code
 
-Your skill code should access credentials through the `Context` object as shown below:
+Your tool code should access credentials through the `Context` object as shown below:
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
-class GetAddressWithAuth(Skill):
+class GetAddressWithAuth(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Get parameters from context
         cep = context.parameters.get("cep", "")
@@ -168,4 +168,4 @@ class GetAddressWithAuth(Skill):
 
 The key line is `api_key = context.credentials.get("api_key")`, which retrieves the credential value that was defined in your agent definition and stored in your `.env` file.
 
-> **Important**: Never hardcode credentials in your skill code. Always access them through the Context object to ensure your code remains secure and works consistently across different environments.
+> **Important**: Never hardcode credentials in your tool code. Always access them through the Context object to ensure your code remains secure and works consistently across different environments.

--- a/docs/user-guide/agents.md
+++ b/docs/user-guide/agents.md
@@ -8,27 +8,27 @@ Agents are defined using YAML files. Here's the basic structure:
 
 ```yaml
 agents:
-  agent_id:
-    name: "Agent Name"
-    description: "Agent Description"
-    instructions:
-      - "Instruction 1"
-      - "Instruction 2"
-    guardrails:
-      - "Guardrail 1"
-    skills:
-      - skill_name:
-          name: "Skill Name"
-          source:
-            path: "skills/skill_name"
-            entrypoint: "main.SkillClass"
-          description: "Skill Description"
-          parameters:
-            - param_name:
-                description: "Parameter Description"
-                type: "string"
-                required: true
-                contact_field: true
+   agent_id:
+      name: "Agent Name"
+      description: "Agent Description"
+      instructions:
+         - "Instruction 1"
+         - "Instruction 2"
+      guardrails:
+         - "Guardrail 1"
+      tools:
+         - tool_name:
+            name: "Tool Name"
+            source:
+               path: "tools/tool_name"
+               entrypoint: "main.ToolClass"
+            description: "Tool Description"
+            parameters:
+               - param_name:
+                  description: "Parameter Description"
+                  type: "string"
+                  required: true
+                  contact_field: true
 ```
 
 ### Key Components
@@ -50,22 +50,22 @@ agents:
    - Define boundaries and limitations
    - Prevent unwanted behavior
 
-5. **Skills**
+5. **Tools**
    - Custom functionalities
    - Implemented as Python classes using the Weni SDK
 
-### Skill Source Configuration
+### Tool Source Configuration
 
-The `source` field is critical for locating and executing your skill:
+The `source` field is critical for locating and executing your tool:
 
 ```yaml
 source:
-  path: "skills/skill_name"
-  entrypoint: "main.SkillClass"
+  path: "tools/tool_name"
+  entrypoint: "main.ToolClass"
 ```
 
-- **path**: Points to the directory containing your skill implementation
-  - Example: `skills/get_address` refers to a folder named `get_address` inside a `skills` directory
+- **path**: Points to the directory containing your tool implementation
+  - Example: `tools/get_address` refers to a folder named `get_address` inside a `tools` directory
   - This folder should contain your Python modules and requirements.txt
 
 - **entrypoint**: Specifies which class to use in which file
@@ -73,28 +73,28 @@ source:
   - Example: `main.GetAddress` means:
     - Look for a file named `main.py` in the path directory
     - Find a class named `GetAddress` inside that file
-    - This class must inherit from the `Skill` class
+    - This class must inherit from the `Tool` class
 
 Your directory structure should look like:
 ```
 project/
 ├── agents.yaml
-└── skills/
+└── tools/
     └── get_address/
         ├── main.py             # Contains GetAddress class
         └── requirements.txt    # Dependencies
 ```
 
-## Creating Skills
+## Creating Tools
 
-### Skill Implementation Structure
+### Tool Implementation Structure
 
 ```python
-from weni import Skill
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 
-class SkillName(Skill):
+class ToolName(Tool):
     def execute(self, context: Context) -> TextResponse:
         # Extract parameters
         parameters = context.parameters
@@ -112,7 +112,7 @@ class SkillName(Skill):
 ```
 
 #### Important Requirements
-- The class **must** inherit from `Skill`
+- The class **must** inherit from `Tool`
 - The class **must** implement the `execute` method
 - The class name **must** match the class name in your entrypoint
 
@@ -128,7 +128,7 @@ weni project push agents.yaml
 
 The command:
 1. Validates your YAML
-2. Uploads skills
+2. Uploads tools
 3. Creates/updates the agent
 
 ### Deployment Best Practices
@@ -140,7 +140,7 @@ The command:
 2. **Testing**
    - Test locally when possible
    - Start with staging environment
-   - Verify all skills work
+   - Verify all tools work
 
 3. **Organization**
    - Use clear file names
@@ -160,14 +160,14 @@ Available parameter types:
 
 ### Response Formats
 
-Skills can return:
+Tools can return:
 - Text responses via `TextResponse`
 - Structured data 
 - Error messages
 
 ### Error Handling
 
-Your skills should:
+Your tools should:
 1. Validate inputs
 2. Handle exceptions gracefully
 3. Return meaningful error messages
@@ -178,12 +178,12 @@ Your skills should:
 
 1. **Deployment Failures**
    - Check YAML syntax
-   - Verify skill paths
+   - Verify tool paths
    - Confirm project selection
 
-2. **Skill Errors**
-   - Verify skill entrypoint (class name)
-   - Test skill class locally
+2. **Tool Errors**
+   - Verify tool entrypoint (class name)
+   - Test tool class locally
    - Check parameter handling in context
    - Verify API endpoints
 
@@ -201,7 +201,7 @@ Your skills should:
 
 2. **Monitoring**
    - Keep deployment logs
-   - Monitor skill performance
+   - Monitor tool performance
    - Track user interactions
 
 3. **Updates**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,11 +88,11 @@ nav:
     - Authentication: getting-started/authentication.md
   - Core Concepts:
     - Agents: core-concepts/agents.md
-    - Skills: core-concepts/skills.md
+    - Tools: core-concepts/tools.md
     - Credentials: core-concepts/credentials.md
     - Contact Fields: core-concepts/contact-fields.md
   - Run:
-    - Run: run/skill-run.md
+    - Tool: run/tool-run.md
   - Examples:
     - Example Gallery: examples/gallery.md
   - Utils:


### PR DESCRIPTION
…ools'

- Updated all references in the documentation and codebase to replace 'skills' with 'tools', aligning with the new terminology.
- Adjusted agent definitions, examples, and implementation details to reflect the change in structure and functionality.
- Created a new tools.md file to define the concept of tools and their usage within the agent framework.
- Enhanced the quickstart guide and user documentation to provide clear instructions on implementing and testing tools.
- Ensured consistency across all examples and test cases to support the new tools paradigm.