### PR TITLE
Update weni-agents-toolkit version to 2.0.0 in poetry.lock and pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1406,13 +1406,13 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "weni-agents-toolkit"
-version = "1.0.0"
+version = "2.0.0"
 description = ""
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "weni_agents_toolkit-1.0.0-py3-none-any.whl", hash = "sha256:a0ea8fe73632d9ca9fa96037570f91ff641eb3c652e08525f015f0d6b443fdf8"},
-    {file = "weni_agents_toolkit-1.0.0.tar.gz", hash = "sha256:457b96217397b5de94ff0608ba16fcf96ca4c937bca67f0e11f6d6698fe6d274"},
+    {file = "weni_agents_toolkit-2.0.0-py3-none-any.whl", hash = "sha256:24280b74baac3c6469017a59bd2fd0ead301bec24395460a92477ce54a8b6e2a"},
+    {file = "weni_agents_toolkit-2.0.0.tar.gz", hash = "sha256:be4c96114524c5a738248bf56d6a51f07017847e2c764f00654d6c0c0c9b42da"},
 ]
 
 [[package]]
@@ -1435,4 +1435,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e56ca832f88e8dbbcfe36b18f7400860f1534179f093a2e15e5a1435147345fb"
+content-hash = "12bbe00ac3de86c730888d09304224dfc3dc1066cdaba86255c38529f86d88cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ waitress = "^3.0.2"
 pyyaml = "^6.0.2"
 python-slugify = "^8.0.4"
 regex = "^2024.11.6"
-weni-agents-toolkit = "1.0.0"
+weni-agents-toolkit = "2.0.0"
 rich-click = "^1.8.6"
 rich = "^13.9.4"
 


### PR DESCRIPTION
- Bumped the version of weni-agents-toolkit from 1.0.0 to 2.0.0.