### PR TITLE
Refactor credential definitions in documentation for consistency

### DIFF
--- a/docs/core-concepts/credentials.md
+++ b/docs/core-concepts/credentials.md
@@ -15,17 +15,17 @@ In your agent definition file (YAML), credentials are defined in the `credential
 agents:
   my_agent:
     credentials:
-      - API_KEY:
-          - label: "API Key"
-          - placeholder: "your-api-key-here"
-          - is_confidential: true
-      - API_SECRET:
-          - label: "API Secret"
-          - placeholder: "your-api-secret-here"
-      - BASE_URL:
-          - label: "Base URL"
-          - placeholder: "https://api.example.com"
-          - is_confidential: false
+      API_KEY:
+        label: "API Key"
+        placeholder: "your-api-key-here"
+        is_confidential: true
+      API_SECRET:
+        label: "API Secret"
+        placeholder: "your-api-secret-here"
+      BASE_URL:
+        label: "Base URL"
+        placeholder: "https://api.example.com"
+        is_confidential: false
 ```
 
 Each credential has the following attributes:
@@ -113,9 +113,9 @@ For example, if your CEP Agent definition has the following credentials:
 agents:
   cep_agent:
     credentials:
-      - api_key:
-          - label: "API Key"
-          - placeholder: "Enter your API key"
+      api_key:
+        label: "API Key"
+        placeholder: "Enter your API key"
     # Rest of the agent definition...
 ```
 

--- a/docs/core-concepts/tools.md
+++ b/docs/core-concepts/tools.md
@@ -160,9 +160,9 @@ To make credentials available to your tool, you need to define them in your agen
 agents:
   cep_agent:
    credentials:
-      - api_key:
-          - label: "API Key"
-          - placeholder: "Api Key"
+      api_key:
+        label: "API Key"
+        placeholder: "Api Key"
     name: "CEP Agent"
     description: "Weni's CEP agent"
     instructions:

--- a/docs/examples/movie-agent.md
+++ b/docs/examples/movie-agent.md
@@ -10,9 +10,9 @@ Create a file called `agent_definition.yaml`:
 agents:
   movie_agent:
     credentials:
-      - movies_api_key:
-          - label: "api movies"
-          - placeholder: "movies_api_key"
+      movies_api_key:
+        label: "api movies"
+        placeholder: "movies_api_key"
     name: "Movie Agent"
     description: "Expert in searching for movie information"
     instructions:

--- a/docs/examples/news-agent.md
+++ b/docs/examples/news-agent.md
@@ -10,9 +10,9 @@ Create a file called `agent_definition.yaml`:
 agents:
     news_agent:
         credentials:
-        - apiKey:
-            - label: "API Key"
-            - placeholder: "apiKey"
+            apiKey:
+                label: "API Key"
+                placeholder: "apiKey"
         name: "News Agent"
         description: "Expert in searching and providing news about any topic"
         instructions:

--- a/docs/run/tool-run.md
+++ b/docs/run/tool-run.md
@@ -92,9 +92,9 @@ First, update your agent definition to include credentials:
 agents:
   cep_agent:
     credentials:
-      - api_key:
-          - label: "API Key"
-          - placeholder: "Api Key"
+      api_key:
+        label: "API Key"
+        placeholder: "Api Key"
     name: "CEP Agent"
     description: "Weni's CEP agent"
     instructions:


### PR DESCRIPTION
Updated the formatting of credential definitions across multiple documentation files to use a consistent YAML structure. This change enhances readability and aligns with recent updates in agent definitions.