### PR TITLE
Refactor documentation and update agent definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A command-line interface (CLI) tool to manage and interact with projects on the 
 
 ## Requirements
 
-- Python >= 3.12
+- Python >= 3.10
 - Poetry >= 1.8.5
 
 ## Installation
@@ -65,7 +65,7 @@ weni project current
 This ensures you're working with the correct project.
 
 ### 5. Create Your Agent Definition
-Create a file named `agents.yaml` (you can use any filename you prefer) with this content:
+Create a file named `agent_definition.yaml` with this content:
 ```yaml
 agents:
   sample_agent:
@@ -100,13 +100,13 @@ mkdir -p tools/get_address
 ### 7. Create the tool Class
 Create a file in `tools/get_address` named `main.py` with this content:
 ```python
-from weni import tool
+from weni import Tool
 from weni.context import Context
 from weni.responses import TextResponse
 import requests
 
 
-class GetAddress(tool):
+class GetAddress(Tool):
     def execute(self, context: Context) -> TextResponse:
         cep = context.parameters.get("cep", "")
         address_response = self.get_address_by_cep(cep=cep)
@@ -125,12 +125,12 @@ Make sure the file folder matches the `path` specified in your `agents.yaml` fil
 Create a `requirements.txt` file in the same folder as your tool with the necessary dependencies:
 
 ```txt
-requests==2.31.0
+requests==2.32.3
 ```
 
 ### 8. Upload Your Agent
 ```bash
-weni project push agents.yaml
+weni project push agent_definition.yaml
 ```
 
 That's it! You've just created your first agent with a custom tool using Weni-CLI. 
@@ -190,7 +190,7 @@ Below is an example of a valid agent definition file structure:
 ```yaml
 agents:
   sample_agent:
-    name: "Sample Agent"                                                                      # Maximum of 128 characters
+    name: "Sample Agent"                                                                      # Maximum of 55 characters
     description: "Weni's sample agent"
     instructions:
       - "You should always be polite, respectful and helpful, even if the user is not."       # Minimum of 40 characters
@@ -199,7 +199,7 @@ agents:
       - "Don't talk about politics, religion or any other sensitive topic. Keep it neutral."  # Minimum of 40 characters
     tools:
       - get_order_status:
-          name: "Get Order Status"                                                            # Maximum of 53 characters
+          name: "Get Order Status"                                                            # Maximum of 40 characters
           source: 
             path: "tools/order_status"
             entrypoint: "main.GetOrderStatus"
@@ -210,7 +210,7 @@ agents:
                 type: "string"
                 required: true
       - get_order_details:
-          name: "Get Order Details"                                                           # Maximum of 53 characters
+          name: "Get Order Details"                                                           # Maximum of 40 characters
           source: 
             path: "tools/order_details"
             entrypoint: "main.GetOrderDetails"

--- a/docs/core-concepts/active-agents.md
+++ b/docs/core-concepts/active-agents.md
@@ -49,7 +49,7 @@ Below are the key elements specific to or different in Active Agent definitions:
 
     `name`
     :   The display name of your agent.  
-        **Limit**: :octicons-alert-24: Maximum of 128 characters.
+        **Limit**: :octicons-alert-24: Maximum of 55 characters.
 
     `description`
     :   A description of the agent's purpose and capabilities.
@@ -80,15 +80,12 @@ Below are the key elements specific to or different in Active Agent definitions:
             `path`: The directory path for the pre-processing code (e.g., `pre_processors/processor`).
 
         `pre_processing.result_examples_file`
-        :   The path to a JSON file containing examples of the data *after* pre-processing and rule execution (if applicable to show final state). The format is an array of objects.
-
-        `pre_processing.pre_result_examples_file`
-        :   The path to a JSON file containing examples of the data *before* pre-processing. The format is an array of objects. (I've added this based on the YAML, please clarify if this understanding is correct or if `pre_result_examples_file` had a different purpose.)
+        :   Required. Path to a JSON file containing examples of the data output from pre-processing. The format is an array of objects.
 
 
 ### Result Example JSON Format
 
-The `result_example.json` (and assumed `pre_result_example.json`) file should follow this structure:
+The `result_example.json` file should follow this structure:
 
 ```json title="result_example.json"
 [

--- a/docs/core-concepts/credentials.md
+++ b/docs/core-concepts/credentials.md
@@ -101,11 +101,7 @@ During development and local testing of your tools, you'll need to provide crede
 
 ### Configuring Credentials for Local Development
 
-For local testing, you can use environment variables or local configuration files:
-
-#### Using Environment Variables
-
-For local testing, you need to configure a `.env` file with the same credential names that were declared in your agent definition. This ensures that your tool can access the credentials in the same way during local testing as it would in production.
+For local testing, the CLI reads a `.env` file located in the tool's `source.path` directory. Define the same credential names that are declared in your agent definition. This mirrors how credentials are injected in production.
 
 For example, if your CEP Agent definition has the following credentials:
 
@@ -119,7 +115,7 @@ agents:
     # Rest of the agent definition...
 ```
 
-You would create a `.env` file in the root of your project with:
+Create a `.env` file inside the tool folder (e.g. `tools/get_address/.env`) with:
 
 ```
 api_key=your-development-api-key

--- a/docs/core-concepts/passive-agents.md
+++ b/docs/core-concepts/passive-agents.md
@@ -37,7 +37,7 @@ agents:
           source: 
             path: "tools/get_address"
             entrypoint: "main.GetAddress"
-            path_test: "tests.yaml"
+            path_test: "test_definition.yaml"
           description: "Function to get the address from the postal code"
           parameters:
             - cep:
@@ -54,7 +54,7 @@ agents:
     `Name`
 
     :   The name of your agent that will be displayed in the Weni Platform.  
-        **Limit**: :octicons-alert-24: Maximum of 128 characters
+        **Limit**: :octicons-alert-24: Maximum of 55 characters
 
     `Credentials`
 
@@ -79,7 +79,7 @@ agents:
     `Name`
 
     :   The name of the tool that will be associated with the agent in the Weni Platform.  
-        **Limit**: :octicons-alert-24: Maximum of 53 characters
+        **Limit**: :octicons-alert-24: Maximum of 40 characters
 
     `Source`
 
@@ -101,7 +101,7 @@ agents:
         
         - `description`: A clear explanation of what the parameter is used for and what kind of data it expects.
         
-        - `type`: The data type of the parameter (e.g., string, integer, boolean, object).
+        - `type`: The data type of the parameter (one of: string, number, integer, boolean, array).
         
         - `required`: A boolean value (true/false) indicating whether the parameter must be provided for the tool to function properly. If set to true, the agent will ask the user for this information if it's not available before proceeding with the request.
         
@@ -129,7 +129,7 @@ agents:
           source: 
             path: "tools/get_address"
             entrypoint: "main.GetAddress"
-            path_test: "tests.yaml"
+            path_test: "test_definition.yaml"
           description: "Function to get the address from the postal code"
           parameters:
             - cep:

--- a/docs/core-concepts/tools.md
+++ b/docs/core-concepts/tools.md
@@ -176,7 +176,7 @@ agents:
           source: 
             path: "tools/get_address"
             entrypoint: "main.GetAddressWithAuth"
-            path_test: "tests.yaml"
+            path_test: "test_definition.yaml"
           description: "Function to get the address from the postal code"
           parameters:
             - cep:

--- a/docs/examples/movie-agent.md
+++ b/docs/examples/movie-agent.md
@@ -147,7 +147,7 @@ For this agent to work properly, you'll need to get an API key from The Movie Da
 
 Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-Since this tool requires credentials, you'll need to create a `.env` file in the root of your project with your TMDB API key:
+Since this tool requires credentials, create a `.env` file in the tool folder with your TMDB API key (e.g., `tools/get_movies/.env`):
 
 ```
 movies_api_key=your_actual_tmdb_api_key_here
@@ -159,7 +159,7 @@ To test the Movie Agent tool:
 weni run agent_definition.yaml movie_agent get_movies
 ```
 
-This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the `.env` file and make them available to your tool during execution.
+This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the tool folder `.env` file and make them available to your tool during execution.
 
 If you need more detailed logs for debugging, you can add the `-v` flag:
 

--- a/docs/examples/news-agent.md
+++ b/docs/examples/news-agent.md
@@ -129,7 +129,7 @@ For this agent to work properly, you'll need to get an API key from News API:
 
 Before deploying your agent, you can test the tool locally using the `weni run` command. This allows you to verify that your tool works correctly and debug any issues.
 
-Since this tool requires credentials, you'll need to create a `.env` file in the root of your project with your API key:
+Since this tool requires credentials, create a `.env` file in the tool folder with your API key (e.g., `tools/get_news/.env`):
 
 ```
 apiKey=your_actual_news_api_key_here
@@ -141,7 +141,7 @@ To test the News Agent tool:
 weni run agent_definition.yaml news_agent get_news
 ```
 
-This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the `.env` file and make them available to your tool during execution.
+This command will execute the tests defined in the `test_definition.yaml` file and show you the output. The CLI will automatically pick up the credentials from the tool folder `.env` file and make them available to your tool during execution.
 
 If you need more detailed logs for debugging, you can add the `-v` flag:
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -18,3 +18,5 @@ After logging in, you will be redirected to the CLI and you will be authenticate
 
 !!! success start "Login Successfully"
     Now you are authenticated and you can start using the Weni CLI with your projects.
+
+The local callback server listens on `http://localhost:50051/sso-callback`. If your browser does not open automatically, copy the URL shown in the terminal and complete the login in your browser.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ This guide will help you install the Weni CLI tool on your system. We provide tw
 
 ## Requirements
 
-- Python >= 3.12
+- Python >= 3.10
 - Poetry >= 1.8.5
 
 ## Installation

--- a/docs/getting-started/quickstart-developers.md
+++ b/docs/getting-started/quickstart-developers.md
@@ -51,7 +51,7 @@ This command will create a new agent with the name `cep_agent` and the tool `get
 
 #### 2.1. Agent Configuration
 
-Create a file named `agents.yaml` with your agent configuration:
+Create a file named `agent_definition.yaml` with your agent configuration:
 
 ```yaml
 agents:
@@ -100,7 +100,7 @@ source:
 Your project structure should look like:
 ```
 my-agent-project/
-├── agents.yaml
+├── agent_definition.yaml
 └── tools/
     └── get_address/
         ├── main.py             # Contains GetAddress class
@@ -146,13 +146,27 @@ my-agent-project/
    Create a `requirements.txt` file:
 
    ```txt
-   requests==2.31.0
+   requests==2.32.3
    ```
+
+4. **(Optional) Add credentials and globals files**
+
+Place these files in `tools/get_address/` if needed during local runs:
+
+```ini
+# .env
+api_key=your-development-api-key
+```
+
+```ini
+# .globals
+BASE_URL=https://api.example.com
+```
 
 ### 3. Deploy Agent
 
 ```bash
-weni project push agents.yaml
+weni project push agent_definition.yaml
 ```
 
 ## Advanced Configuration

--- a/docs/run/logs.md
+++ b/docs/run/logs.md
@@ -1,0 +1,43 @@
+# Logs
+
+Fetch and filter execution logs for a specific agent tool.
+
+## Usage
+
+```bash
+weni logs --agent <agent_key> --tool <tool_key> [--start-time ISO8601] [--end-time ISO8601] [--pattern TEXT]
+```
+
+### Options
+
+- `--agent, -a` (required): Agent key in your definition (e.g. `cep_agent`).
+- `--tool, -t` (required): Tool key (e.g. `get_address`).
+- `--start-time, -s` (optional): ISO 8601 datetime. Examples:
+  - `2024-01-01T00:00:00`
+  - `2024-01-01T00:00:00.000Z`
+- `--end-time, -e` (optional): ISO 8601 datetime, same formats as start.
+- `--pattern, -p` (optional): Simple substring filter. Regex (e.g. `%...%`) is not supported.
+
+Supported datetime formats include:
+
+- `YYYY-MM-DDTHH:MM:SS`
+- `YYYY-MM-DDTHH:MM:SS.sss`
+- With timezone suffix: `Z`, `+00:00`, etc.
+
+### Pagination
+
+If more logs are available, you'll be prompted to fetch more. Choose `p` to continue or `q` to stop.
+
+### Examples
+
+```bash
+# Basic
+weni logs -a cep_agent -t get_address
+
+# With time range
+weni logs -a cep_agent -t get_address -s 2024-01-01T00:00:00 -e 2024-01-01T23:59:59
+
+# With simple pattern
+weni logs -a cep_agent -t get_address -p error
+```
+

--- a/docs/run/tool-run.md
+++ b/docs/run/tool-run.md
@@ -1,4 +1,4 @@
-# Tool Run
+# Tool Test Run
 
 Tool Run is a scalable way to build your tool and test it in real-time. With this feature, it's simple to debug problems and create a tool that is both scalable and performant at the same time.
 
@@ -15,7 +15,7 @@ tools:
       source: 
         path: "tools/get_address"
         entrypoint: "main.GetAddressWithAuth"
-        path_test: "test.yaml"
+        path_test: "test_definition.yaml"
       description: "Function to get the address from the postal code"
       parameters:
         - cep:
@@ -29,7 +29,7 @@ Notice that my tool has a specific parameter called "cep". Therefore, the expect
 
 My test file would look something like this:
 
-**test.yaml:**
+**test_definition.yaml:**
 
 ```yaml
 tests:
@@ -55,7 +55,7 @@ Following the previous steps, we can now run a test, but how?
 The command works as follows:
 
 ```
-weni run [agent definition file] [agent name] [tool name]
+weni run [agent_definition_file] [agent_key] [tool_key] [-f FILE] [-v]
 ```
 
 A practical example of the command considering the agent definition that was mentioned above would be:
@@ -73,6 +73,20 @@ There is also a variation of this command in case you need to include ways to de
 ```
 weni run agent_definition.yaml cep_agent get_address -v
 ``` 
+### Choosing a test file
+
+- Use `-f/--file` to specify a test definition YAML located in the tool folder.
+- If `-f` is omitted, the CLI looks for `test_definition.yaml` in the tool's `source.path` directory.
+- You can also set `source.path_test` in your agent definition to point to a custom test file; when present, the CLI uses that path by default.
+
+### Credentials and globals discovery
+
+For development, the CLI will read optional files from the tool directory:
+
+- `.env` for credentials exposed to your tool via `context.credentials`
+- `.globals` for key/value pairs exposed via `context.globals`
+
+Both files follow a simple `KEY=VALUE` per line format.
 
 Result:
 
@@ -108,7 +122,7 @@ agents:
           source: 
             path: "tools/get_address"
             entrypoint: "main.GetAddressWithAuth"
-            path_test: "test.yaml"
+            path_test: "test_definition.yaml"
           description: "Function to get the address from the postal code"
           parameters:
             - cep:
@@ -118,7 +132,7 @@ agents:
                 contact_field: true
 ```
 
-Then, create a `.env` file in the root of your project with the actual credential values:
+Then, create a `.env` file inside the tool folder (e.g., `tools/get_address/.env`) with the actual credential values:
 
 ```
 api_key=your_actual_api_key_here
@@ -130,7 +144,7 @@ Now you can run your tool test with credentials using the same command:
 weni run agent_definition.yaml cep_agent get_address
 ```
 
-The CLI will automatically pick up the credentials from the `.env` file and make them available to your tool during execution.
+The CLI will automatically pick up the credentials from the tool folder `.env` file and make them available to your tool during execution.
 
 ### Accessing Credentials in Your Tool Code
 
@@ -166,6 +180,6 @@ class GetAddressWithAuth(Tool):
         return response.json()
 ```
 
-The key line is `api_key = context.credentials.get("api_key")`, which retrieves the credential value that was defined in your agent definition and stored in your `.env` file.
+The key line is `api_key = context.credentials.get("api_key")`, which retrieves the credential value that was defined in your agent definition and stored in your tool folder `.env` file.
 
 > **Important**: Never hardcode credentials in your tool code. Always access them through the Context object to ensure your code remains secure and works consistently across different environments.

--- a/docs/user-guide/agents.md
+++ b/docs/user-guide/agents.md
@@ -38,7 +38,7 @@ agents:
    - Used internally by the system
 
 2. **Basic Information**
-   - `name`: Display name (max 128 characters)
+   - `name`: Display name (max 55 characters)
    - `description`: Brief description of the agent's purpose
 
 3. **Instructions**
@@ -154,9 +154,9 @@ The command:
 Available parameter types:
 - `string`
 - `number`
+- `integer`
 - `boolean`
 - `array`
-- `object`
 
 ### Response Formats
 

--- a/docs/user-guide/authentication.md
+++ b/docs/user-guide/authentication.md
@@ -17,17 +17,15 @@ The following happens:
 3. After successful login, you're redirected back to the local server
 4. The CLI receives and stores your authentication token
 
+By default, the local server listens on `http://localhost:50051/sso-callback`.
+
 ## Token Storage
 
 Your authentication token is stored securely in your home directory. Never share or expose your authentication information.
 
 ## Token Refresh
 
-Tokens are automatically refreshed when needed. You don't need to manually re-login unless:
-
-- You've logged out
-- Your token was revoked
-- You want to switch accounts
+If an API request returns an authentication error, the CLI will prompt you to login again. Run `weni login` to obtain a new token, or set a different account.
 
 ## Logout
 

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -12,6 +12,14 @@ View all projects you have access to:
 weni project list
 ```
 
+Filter projects by organization UUID:
+
+```bash
+weni project list --org <org-uuid>
+```
+
+If many results are available, you'll be prompted to load more pages (`p`) or quit (`q`).
+
 This command shows:
 - Project UUID
 - Project name
@@ -36,11 +44,7 @@ Check which project you're currently working with:
 weni project current
 ```
 
-This shows:
-- Project UUID
-- Project name
-- Organization
-- Other relevant details
+This prints the current project UUID stored by the CLI, e.g.: `Current project: <uuid>`
 
 ## Project Context
 

--- a/docs/utils/commands-glossary.md
+++ b/docs/utils/commands-glossary.md
@@ -9,8 +9,9 @@ These commands are fundamental for developing and deploying agents, allowing dir
 | `weni init` | Creates an initial setup ready for use and learning with Weni. |
 | `weni login` | This is how authentication happens. Use it to authenticate according to your Weni platform account. |
 | `weni project list` | Existing projects in your account will be listed using this command. |
+| `weni project list --org <org_uuid>` | Lists only projects from the specified organization UUID. |
 | `weni project use [project_uuid]` | With this command you can choose a specific project to work with by providing its UUID. |
 | `weni project current` | Use this to identify the project identifier you are currently working with. |
-| `weni project push [agent_definition_file]` | This command allows you to deploy/update your agents using the specified agent definition file. |
-| `weni run [agent definition file] [agent name] [tool name]` | Run a specific tool from an agent locally for testing purposes. |
-| `weni run [agent definition file] [agent name] [tool name] -v` | Run a tool with verbose mode enabled, showing detailed logs for debugging. |
+| `weni project push [agent_definition_file] [--force-update]` | Deploy/update your agents using the specified agent definition file. |
+| `weni run [agent_definition_file] [agent_key] [tool_key] [-f FILE] [-v]` | Run a specific tool from an agent locally. `-f/--file` lets you choose a test file; if omitted the CLI looks for `test_definition.yaml` in the tool folder. `-v` enables verbose logs. |
+| `weni logs --agent <agent_key> --tool <tool_key> [--start-time ISO8601] [--end-time ISO8601] [--pattern TEXT]` | Fetch tool execution logs. Supports pagination and ISO 8601 date formats (e.g. `2024-01-01T00:00:00`). |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,8 @@ nav:
     - Credentials: core-concepts/credentials.md
     - Contact Fields: core-concepts/contact-fields.md
   - Run:
-    - Tool: run/tool-run.md
+    - Tool Tests: run/tool-run.md
+    - Logs: run/logs.md
   - Examples:
     - Example Gallery: examples/gallery.md
   - Utils:


### PR DESCRIPTION
- Changed references from `agents.yaml` to `agent_definition.yaml` for consistency.
- Updated Python version requirement from 3.12 to 3.10 in installation guides.
- Adjusted character limits for agent names and tool names in various documentation files.
- Added new logs documentation for fetching execution logs of agent tools.
- Renamed test files from `test.yaml` to `test_definition.yaml` across multiple examples and guides.
- Improved instructions for local development credential configuration.
- Enhanced clarity in agent and tool definitions within the user guide.