### PR TITLE
refactor: change log class from standard to infrequent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.6.7] - 2026-05-07
+
+### Added
+
+- Change log class from standard to infrequent access ([#154](https://github.com/weni-ai/weni-cli/pull/154)) ([**@MatheusLeall**](https://github.com/MatheusLeall))
+
 ## [3.6.6] - 2026-04-15
 
 ### Added

--- a/docs/run/logs.md
+++ b/docs/run/logs.md
@@ -16,7 +16,7 @@ weni logs --agent <agent_key> --tool <tool_key> [--start-time ISO8601] [--end-ti
   - `2024-01-01T00:00:00`
   - `2024-01-01T00:00:00.000Z`
 - `--end-time, -e` (optional): ISO 8601 datetime, same formats as start.
-- `--pattern, -p` (optional): Simple substring filter. Regex (e.g. `%...%`) is not supported.
+- `--pattern, -p` (optional): Simple substring filter (case-sensitive). Regex (e.g. `%...%`) is not supported.
 
 Supported datetime formats include:
 
@@ -27,6 +27,10 @@ Supported datetime formats include:
 ### Pagination
 
 If more logs are available, you'll be prompted to fetch more. Choose `p` to continue or `q` to stop.
+
+### Performance notes
+
+Log queries run against CloudWatch Logs Insights and may take a few seconds to return on the first page (typically 1–5 seconds depending on the time window and log volume). Narrower time windows return faster.
 
 ### Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-cli"
-version = "3.6.6"
+version = "3.6.7"
 description = ""
 authors = ["Paulo Bernardo <paulo.bernardo@weni.ai>", "Matheus Leal <matheus.cardoso@vtex.com>"]
 readme = "README.md"

--- a/weni_cli/commands/logs.py
+++ b/weni_cli/commands/logs.py
@@ -20,7 +20,7 @@ class GetLogsHandler:
                 formatter.print_error_panel("Regex patterns are not supported")
                 return
 
-            with console.status("Fetching logs...", spinner="dots"):
+            with console.status("Querying logs...", spinner="dots"):
                 logs_response, error = client.get_tool_logs(agent, tool, start_time, end_time, pattern, current_token)
 
             if error:


### PR DESCRIPTION
With the centralization of the lambda log group and the change of the log group class from `standard` to `infrequent access`, it was necessary to make some changes and adaptations to `weni-cli` and `weni-cli-backend`. This PR addresses these changes.